### PR TITLE
Chore op2

### DIFF
--- a/src/node/adult_duties/chunks/mod.rs
+++ b/src/node/adult_duties/chunks/mod.rs
@@ -11,7 +11,7 @@ mod reading;
 mod writing;
 
 use crate::{
-    node::node_ops::{NodeDuty, NodeMessagingDuty, NodeOperation},
+    node::node_ops::{NodeDuty, NodeMessagingDuty, },
     AdultState, NodeInfo, Result,
 };
 use chunk_storage::ChunkStorage;
@@ -59,12 +59,12 @@ impl Chunks {
         writing::get_result(write, msg_id, origin, &mut self.chunk_storage).await
     }
 
-    pub async fn check_storage(&self) -> Result<NodeOperation> {
+    pub async fn check_storage(&self) -> Result<Vec<NetworkDuty>> {
         info!("Checking used storage");
         if self.chunk_storage.used_space_ratio().await > MAX_STORAGE_USAGE_RATIO {
             Ok(NodeDuty::StorageFull.into())
         } else {
-            Ok(NodeOperation::NoOp)
+            Ok(vec![])
         }
     }
 

--- a/src/node/adult_duties/chunks/mod.rs
+++ b/src/node/adult_duties/chunks/mod.rs
@@ -11,7 +11,7 @@ mod reading;
 mod writing;
 
 use crate::{
-    node::node_ops::{NodeDuty, NodeMessagingDuty, },
+    node::node_ops::{NetworkDuties, NodeDuty, NodeMessagingDuty},
     AdultState, NodeInfo, Result,
 };
 use chunk_storage::ChunkStorage;
@@ -59,10 +59,10 @@ impl Chunks {
         writing::get_result(write, msg_id, origin, &mut self.chunk_storage).await
     }
 
-    pub async fn check_storage(&self) -> Result<Vec<NetworkDuty>> {
+    pub async fn check_storage(&self) -> Result<NetworkDuties> {
         info!("Checking used storage");
         if self.chunk_storage.used_space_ratio().await > MAX_STORAGE_USAGE_RATIO {
-            Ok(NodeDuty::StorageFull.into())
+            Ok(NetworkDuties::from(NodeDuty::StorageFull))
         } else {
             Ok(vec![])
         }

--- a/src/node/adult_duties/mod.rs
+++ b/src/node/adult_duties/mod.rs
@@ -12,7 +12,7 @@ use self::chunks::Chunks;
 use crate::{
     node::node_ops::{
         AdultDuty, ChunkReplicationCmd, ChunkReplicationDuty, ChunkReplicationQuery,
-        ChunkStoreDuty, IntoNodeOp,
+        ChunkStoreDuty, NetworkDuties, NetworkDuty,
     },
     AdultState, NodeInfo, Result,
 };
@@ -36,25 +36,29 @@ impl AdultDuties {
         &self.state
     }
 
-    pub async fn process_adult_duty(&mut self, duty: AdultDuty) -> Result<Vec<NetworkDuty>> {
+    pub async fn process_adult_duty(&mut self, duty: AdultDuty) -> Result<NetworkDuties> {
         use AdultDuty::*;
         use ChunkReplicationCmd::*;
         use ChunkReplicationDuty::*;
         use ChunkReplicationQuery::*;
         use ChunkStoreDuty::*;
-        let result: Result<Vec<NetworkDuty>> = match duty {
+        let result: Result<NetworkDuties> = match duty {
             RunAsChunkStore(chunk_duty) => match chunk_duty {
                 ReadChunk { read, id, origin } => {
-                    let mut ops = vec![];
-                    ops.push(self.chunks.read(&read, id, origin).await.convert());
-                    ops.push(self.chunks.check_storage().await);
-                    Ok(ops.into())
+                    let mut ops: NetworkDuties = vec![];
+                    ops.push(NetworkDuty::from(
+                        self.chunks.read(&read, id, origin).await?,
+                    ));
+                    ops.extend(self.chunks.check_storage().await?);
+                    Ok(ops)
                 }
                 WriteChunk { write, id, origin } => {
-                    let mut ops = vec![];
-                    ops.push(self.chunks.write(&write, id, origin).await.convert());
-                    ops.push(self.chunks.check_storage().await);
-                    Ok(ops.into())
+                    let mut ops: NetworkDuties = vec![];
+                    ops.push(NetworkDuty::from(
+                        self.chunks.write(&write, id, origin).await?,
+                    ));
+                    ops.extend(self.chunks.check_storage().await?);
+                    Ok(ops)
                 }
                 ChunkStoreDuty::NoOp => return Ok(vec![]),
             },
@@ -63,23 +67,23 @@ impl AdultDuties {
                     query: GetChunk(address),
                     msg_id,
                     origin,
-                } => self
-                    .chunks
-                    .get_chunk_for_replication(address, msg_id, origin)
-                    .await
-                    .convert(),
+                } => Ok(NetworkDuties::from(
+                    self.chunks
+                        .get_chunk_for_replication(address, msg_id, origin)
+                        .await?,
+                )),
                 ProcessCmd { cmd, msg_id, .. } => match cmd {
-                    StoreReplicatedBlob(blob) => {
-                        self.chunks.store_replicated_chunk(blob).await.convert()
-                    }
+                    StoreReplicatedBlob(blob) => Ok(NetworkDuties::from(
+                        self.chunks.store_replicated_chunk(blob).await?,
+                    )),
                     ReplicateChunk {
                         address,
                         current_holders,
-                    } => self
-                        .chunks
-                        .replicate_chunk(address, current_holders, msg_id)
-                        .await
-                        .convert(),
+                    } => Ok(NetworkDuties::from(
+                        self.chunks
+                            .replicate_chunk(address, current_holders, msg_id)
+                            .await?,
+                    )),
                 },
                 ChunkReplicationDuty::NoOp => return Ok(vec![]),
             },

--- a/src/node/adult_duties/mod.rs
+++ b/src/node/adult_duties/mod.rs
@@ -12,7 +12,7 @@ use self::chunks::Chunks;
 use crate::{
     node::node_ops::{
         AdultDuty, ChunkReplicationCmd, ChunkReplicationDuty, ChunkReplicationQuery,
-        ChunkStoreDuty, IntoNodeOp, NodeOperation,
+        ChunkStoreDuty, IntoNodeOp,
     },
     AdultState, NodeInfo, Result,
 };
@@ -36,13 +36,13 @@ impl AdultDuties {
         &self.state
     }
 
-    pub async fn process_adult_duty(&mut self, duty: AdultDuty) -> Result<NodeOperation> {
+    pub async fn process_adult_duty(&mut self, duty: AdultDuty) -> Result<Vec<NetworkDuty>> {
         use AdultDuty::*;
         use ChunkReplicationCmd::*;
         use ChunkReplicationDuty::*;
         use ChunkReplicationQuery::*;
         use ChunkStoreDuty::*;
-        let result: Result<NodeOperation> = match duty {
+        let result: Result<Vec<NetworkDuty>> = match duty {
             RunAsChunkStore(chunk_duty) => match chunk_duty {
                 ReadChunk { read, id, origin } => {
                     let mut ops = vec![];
@@ -56,7 +56,7 @@ impl AdultDuties {
                     ops.push(self.chunks.check_storage().await);
                     Ok(ops.into())
                 }
-                ChunkStoreDuty::NoOp => return Ok(NodeOperation::NoOp),
+                ChunkStoreDuty::NoOp => return Ok(vec![]),
             },
             RunAsChunkReplication(replication_duty) => match replication_duty {
                 ProcessQuery {
@@ -81,9 +81,9 @@ impl AdultDuties {
                         .await
                         .convert(),
                 },
-                ChunkReplicationDuty::NoOp => return Ok(NodeOperation::NoOp),
+                ChunkReplicationDuty::NoOp => return Ok(vec![]),
             },
-            _ => return Ok(NodeOperation::NoOp),
+            _ => return Ok(vec![]),
         };
 
         result

--- a/src/node/elder_duties/data_section/metadata/blob_register.rs
+++ b/src/node/elder_duties/data_section/metadata/blob_register.rs
@@ -9,7 +9,7 @@
 use crate::{
     capacity::ChunkHolderDbs,
     error::convert_to_error_message,
-    node::node_ops::{NodeMessagingDuty, OutgoingMsg},
+    node::node_ops::{NetworkDuties, NetworkDuty, NodeMessagingDuty, OutgoingMsg},
     ElderState, Error, Result, ToDbKey,
 };
 use log::{info, trace, warn};
@@ -303,7 +303,7 @@ impl BlobRegister {
         Ok(())
     }
 
-    pub(super) async fn replicate_chunks(&mut self, holder: XorName) -> Result<Vec<NetworkDuty>> {
+    pub(super) async fn replicate_chunks(&mut self, holder: XorName) -> Result<NetworkDuties> {
         trace!("Replicating chunks of holder {:?}", holder);
 
         let chunks_stored = match self.remove_holder(holder) {
@@ -314,14 +314,14 @@ impl BlobRegister {
         for (address, holders) in chunks_stored {
             cmds.extend(self.get_replication_msgs(address, holders).await);
         }
-        Ok(cmds.into())
+        Ok(cmds)
     }
 
     async fn get_replication_msgs(
         &self,
         address: BlobAddress,
         current_holders: BTreeSet<XorName>,
-    ) -> Vec<Vec<NetworkDuty>> {
+    ) -> NetworkDuties {
         use NodeCmd::*;
         use NodeSystemCmd::*;
         let mut node_ops = Vec::new();

--- a/src/node/elder_duties/data_section/metadata/blob_register.rs
+++ b/src/node/elder_duties/data_section/metadata/blob_register.rs
@@ -9,7 +9,7 @@
 use crate::{
     capacity::ChunkHolderDbs,
     error::convert_to_error_message,
-    node::node_ops::{NetworkDuties, NetworkDuty, NodeMessagingDuty, OutgoingMsg},
+    node::node_ops::{NetworkDuties, NodeMessagingDuty, OutgoingMsg},
     ElderState, Error, Result, ToDbKey,
 };
 use log::{info, trace, warn};

--- a/src/node/elder_duties/data_section/metadata/blob_register.rs
+++ b/src/node/elder_duties/data_section/metadata/blob_register.rs
@@ -9,7 +9,7 @@
 use crate::{
     capacity::ChunkHolderDbs,
     error::convert_to_error_message,
-    node::node_ops::{NodeMessagingDuty, NodeOperation, OutgoingMsg},
+    node::node_ops::{NodeMessagingDuty, OutgoingMsg},
     ElderState, Error, Result, ToDbKey,
 };
 use log::{info, trace, warn};
@@ -303,12 +303,12 @@ impl BlobRegister {
         Ok(())
     }
 
-    pub(super) async fn replicate_chunks(&mut self, holder: XorName) -> Result<NodeOperation> {
+    pub(super) async fn replicate_chunks(&mut self, holder: XorName) -> Result<Vec<NetworkDuty>> {
         trace!("Replicating chunks of holder {:?}", holder);
 
         let chunks_stored = match self.remove_holder(holder) {
             Ok(chunks) => chunks,
-            _ => return Ok(NodeOperation::NoOp),
+            _ => return Ok(vec![]),
         };
         let mut cmds = Vec::new();
         for (address, holders) in chunks_stored {
@@ -321,7 +321,7 @@ impl BlobRegister {
         &self,
         address: BlobAddress,
         current_holders: BTreeSet<XorName>,
-    ) -> Vec<NodeOperation> {
+    ) -> Vec<Vec<NetworkDuty>> {
         use NodeCmd::*;
         use NodeSystemCmd::*;
         let mut node_ops = Vec::new();

--- a/src/node/elder_duties/data_section/metadata/mod.rs
+++ b/src/node/elder_duties/data_section/metadata/mod.rs
@@ -15,7 +15,7 @@ mod writing;
 
 use crate::{
     capacity::ChunkHolderDbs,
-    node::node_ops::{MetadataDuty, },
+    node::node_ops::{MetadataDuty, NetworkDuties},
     node::NodeInfo,
     ElderState, Result,
 };
@@ -49,7 +49,7 @@ impl Metadata {
         Ok(Self { elder_stores })
     }
 
-    pub async fn process_metadata_duty(&mut self, duty: MetadataDuty) -> Result<Vec<NetworkDuty>> {
+    pub async fn process_metadata_duty(&mut self, duty: MetadataDuty) -> Result<NetworkDuties> {
         use MetadataDuty::*;
         match duty {
             ProcessRead { query, id, origin } => {
@@ -65,7 +65,7 @@ impl Metadata {
     // This should be called whenever a node leaves the section. It fetches the list of data that was
     // previously held by the node and requests the other holders to store an additional copy.
     // The list of holders is also updated by removing the node that left.
-    pub async fn trigger_chunk_replication(&mut self, node: XorName) -> Result<Vec<NetworkDuty>> {
+    pub async fn trigger_chunk_replication(&mut self, node: XorName) -> Result<NetworkDuties> {
         self.elder_stores
             .blob_register_mut()
             .replicate_chunks(node)

--- a/src/node/elder_duties/data_section/metadata/reading.rs
+++ b/src/node/elder_duties/data_section/metadata/reading.rs
@@ -12,7 +12,7 @@ use super::{
     blob_register::BlobRegister, elder_stores::ElderStores, map_storage::MapStorage,
     sequence_storage::SequenceStorage,
 };
-use crate::node::node_ops::{IntoNodeOp, NodeMessagingDuty, };
+use crate::node::node_ops::{NetworkDuties, NodeMessagingDuty};
 use crate::Result;
 use sn_messaging::{
     client::{BlobRead, DataQuery, MapRead, SequenceRead},
@@ -25,14 +25,15 @@ pub(super) async fn get_result(
     msg_id: MessageId,
     origin: EndUser,
     stores: &ElderStores,
-) -> Result<Vec<NetworkDuty>> {
+) -> Result<NetworkDuties> {
     use DataQuery::*;
-    match &query {
-        Blob(read) => blob(read, stores.blob_register(), msg_id, origin).await,
-        Map(read) => map(read, stores.map_storage(), msg_id, origin).await,
-        Sequence(read) => sequence(read, stores.sequence_storage(), msg_id, origin).await,
-    }
-    .convert()
+    let duty = match &query {
+        Blob(read) => blob(read, stores.blob_register(), msg_id, origin).await?,
+        Map(read) => map(read, stores.map_storage(), msg_id, origin).await?,
+        Sequence(read) => sequence(read, stores.sequence_storage(), msg_id, origin).await?,
+    };
+
+    Ok(NetworkDuties::from(duty))
 }
 
 async fn blob(

--- a/src/node/elder_duties/data_section/metadata/reading.rs
+++ b/src/node/elder_duties/data_section/metadata/reading.rs
@@ -12,7 +12,7 @@ use super::{
     blob_register::BlobRegister, elder_stores::ElderStores, map_storage::MapStorage,
     sequence_storage::SequenceStorage,
 };
-use crate::node::node_ops::{IntoNodeOp, NodeMessagingDuty, NodeOperation};
+use crate::node::node_ops::{IntoNodeOp, NodeMessagingDuty, };
 use crate::Result;
 use sn_messaging::{
     client::{BlobRead, DataQuery, MapRead, SequenceRead},
@@ -25,7 +25,7 @@ pub(super) async fn get_result(
     msg_id: MessageId,
     origin: EndUser,
     stores: &ElderStores,
-) -> Result<NodeOperation> {
+) -> Result<Vec<NetworkDuty>> {
     use DataQuery::*;
     match &query {
         Blob(read) => blob(read, stores.blob_register(), msg_id, origin).await,

--- a/src/node/elder_duties/data_section/metadata/writing.rs
+++ b/src/node/elder_duties/data_section/metadata/writing.rs
@@ -10,7 +10,7 @@ use super::{
     blob_register::BlobRegister, elder_stores::ElderStores, map_storage::MapStorage,
     sequence_storage::SequenceStorage,
 };
-use crate::node::node_ops::{IntoNodeOp, NodeMessagingDuty, NodeOperation};
+use crate::node::node_ops::{IntoNodeOp, NodeMessagingDuty, };
 use crate::Result;
 use log::info;
 use sn_messaging::{
@@ -24,7 +24,7 @@ pub(super) async fn get_result(
     msg_id: MessageId,
     origin: EndUser,
     stores: &mut ElderStores,
-) -> Result<NodeOperation> {
+) -> Result<Vec<NetworkDuty>> {
     use DataCmd::*;
     info!("Writing Data");
     match cmd {

--- a/src/node/elder_duties/data_section/metadata/writing.rs
+++ b/src/node/elder_duties/data_section/metadata/writing.rs
@@ -10,7 +10,7 @@ use super::{
     blob_register::BlobRegister, elder_stores::ElderStores, map_storage::MapStorage,
     sequence_storage::SequenceStorage,
 };
-use crate::node::node_ops::{IntoNodeOp, NodeMessagingDuty, };
+use crate::node::node_ops::{NetworkDuties, NetworkDuty, NodeMessagingDuty};
 use crate::Result;
 use log::info;
 use sn_messaging::{
@@ -24,24 +24,25 @@ pub(super) async fn get_result(
     msg_id: MessageId,
     origin: EndUser,
     stores: &mut ElderStores,
-) -> Result<Vec<NetworkDuty>> {
+) -> Result<NetworkDuties> {
     use DataCmd::*;
     info!("Writing Data");
-    match cmd {
+    let duty = match cmd {
         Blob(write) => {
             info!("Writing Blob");
-            blob(write, stores.blob_register_mut(), msg_id, origin).await
+            blob(write, stores.blob_register_mut(), msg_id, origin).await?
         }
         Map(write) => {
             info!("Writing Map");
-            map(write, stores.map_storage_mut(), msg_id, origin).await
+            map(write, stores.map_storage_mut(), msg_id, origin).await?
         }
         Sequence(write) => {
             info!("Writing Sequence");
-            sequence(write, stores.sequence_storage_mut(), msg_id, origin).await
+            sequence(write, stores.sequence_storage_mut(), msg_id, origin).await?
         }
-    }
-    .convert()
+    };
+
+    Ok(NetworkDuties::from(duty))
 }
 
 async fn blob(

--- a/src/node/elder_duties/data_section/metadata/writing.rs
+++ b/src/node/elder_duties/data_section/metadata/writing.rs
@@ -10,7 +10,7 @@ use super::{
     blob_register::BlobRegister, elder_stores::ElderStores, map_storage::MapStorage,
     sequence_storage::SequenceStorage,
 };
-use crate::node::node_ops::{NetworkDuties, NetworkDuty, NodeMessagingDuty};
+use crate::node::node_ops::{NetworkDuties, NodeMessagingDuty};
 use crate::Result;
 use log::info;
 use sn_messaging::{

--- a/src/node/elder_duties/data_section/mod.rs
+++ b/src/node/elder_duties/data_section/mod.rs
@@ -15,7 +15,7 @@ use self::{
 };
 use crate::{
     capacity::ChunkHolderDbs,
-    node::node_ops::{DataSectionDuty, NetworkDuties, NetworkDuty, RewardCmd, RewardDuty},
+    node::node_ops::{DataSectionDuty, NetworkDuties, RewardCmd, RewardDuty},
     node::NodeInfo,
     ElderState, Result,
 };

--- a/src/node/elder_duties/data_section/mod.rs
+++ b/src/node/elder_duties/data_section/mod.rs
@@ -15,7 +15,7 @@ use self::{
 };
 use crate::{
     capacity::ChunkHolderDbs,
-    node::node_ops::{DataSectionDuty, RewardCmd, RewardDuty},
+    node::node_ops::{DataSectionDuty, NetworkDuties, NetworkDuty, RewardCmd, RewardDuty},
     node::NodeInfo,
     ElderState, Result,
 };
@@ -127,7 +127,7 @@ impl DataSection {
     pub async fn process_data_section_duty(
         &mut self,
         duty: DataSectionDuty,
-    ) -> Result<Vec<NetworkDuty>> {
+    ) -> Result<NetworkDuties> {
         use DataSectionDuty::*;
         match duty {
             RunAsMetadata(duty) => self.metadata.process_metadata_duty(duty).await,
@@ -138,7 +138,7 @@ impl DataSection {
 
     /// Issues query to Elders of the section
     /// as to catch up with the current state of the replicas.
-    pub async fn catchup_with_section(&mut self) -> Result<Vec<NetworkDuty>> {
+    pub async fn catchup_with_section(&mut self) -> Result<NetworkDuties> {
         self.rewards
             .get_section_wallet_history(self.elder_state.prefix().name())
             .await
@@ -148,7 +148,7 @@ impl DataSection {
     pub async fn initiate_elder_change(
         &mut self,
         elder_state: ElderState,
-    ) -> Result<Vec<NetworkDuty>> {
+    ) -> Result<NetworkDuties> {
         info!("Processing Elder change in data section");
         // TODO: Query sn_routing for info for [new_section_key]
         // specifically (regardless of how far back that was) - i.e. not the current info!
@@ -161,7 +161,7 @@ impl DataSection {
     }
 
     /// At section split, all Elders get their reward payout.
-    pub async fn split_section(&mut self, prefix: Prefix) -> Result<Vec<NetworkDuty>> {
+    pub async fn split_section(&mut self, prefix: Prefix) -> Result<NetworkDuties> {
         // First remove nodes that are no longer in our section.
         let to_remove = self
             .rewards
@@ -177,7 +177,7 @@ impl DataSection {
     }
 
     /// When a new node joins, it is registered for receiving rewards.
-    pub async fn new_node_joined(&mut self, id: XorName) -> Result<Vec<NetworkDuty>> {
+    pub async fn new_node_joined(&mut self, id: XorName) -> Result<NetworkDuties> {
         self.rewards
             .process_reward_duty(RewardDuty::ProcessCmd {
                 cmd: RewardCmd::AddNewNode(id),
@@ -195,7 +195,7 @@ impl DataSection {
         old_node_id: XorName,
         new_node_id: XorName,
         age: u8,
-    ) -> Result<Vec<NetworkDuty>> {
+    ) -> Result<NetworkDuties> {
         // Adds the relocated account.
         self.rewards
             .process_reward_duty(RewardDuty::ProcessCmd {
@@ -212,16 +212,16 @@ impl DataSection {
 
     /// Name of the node
     /// Age of the node
-    pub async fn member_left(&mut self, node_id: XorName, _age: u8) -> Result<Vec<NetworkDuty>> {
-        let first = self
+    pub async fn member_left(&mut self, node_id: XorName, _age: u8) -> Result<NetworkDuties> {
+        let mut duties = self
             .rewards
             .process_reward_duty(RewardDuty::ProcessCmd {
                 cmd: RewardCmd::DeactivateNode(node_id),
                 msg_id: MessageId::new(),
                 origin: SrcLocation::Node(self.elder_state.node_name()),
             })
-            .await;
-        let second = self.metadata.trigger_chunk_replication(node_id).await;
-        Ok(vec![first, second].into())
+            .await?;
+        duties.extend(self.metadata.trigger_chunk_replication(node_id).await?);
+        Ok(duties)
     }
 }

--- a/src/node/elder_duties/data_section/rewards/mod.rs
+++ b/src/node/elder_duties/data_section/rewards/mod.rs
@@ -14,8 +14,7 @@ use self::section_funds::{Payout, SectionFunds};
 pub use self::{reward_calc::RewardCalc, validator::Validator};
 use crate::{
     node::node_ops::{
-        IntoNodeOp, NodeMessagingDuty,  OutgoingMsg, RewardCmd, RewardDuty,
-        RewardQuery,
+        NetworkDuties, NodeMessagingDuty, OutgoingMsg, RewardCmd, RewardDuty, RewardQuery,
     },
     ElderState,
 };
@@ -93,7 +92,7 @@ impl Rewards {
     /// Issues a query to existing Replicas
     /// asking for their events, as to catch up and
     /// start working properly in the group.
-    pub async fn get_section_wallet_history(&self, section: XorName) -> Result<Vec<NetworkDuty>> {
+    pub async fn get_section_wallet_history(&self, section: XorName) -> Result<NetworkDuties> {
         info!("Rewards: Catching up with our section wallet history!");
         // prepare actor init
         Ok(NodeMessagingDuty::Send(OutgoingMsg {
@@ -110,14 +109,13 @@ impl Rewards {
 
     /// After Elder change, we transition to a new
     /// transfer actor, as there is now a new keypair for it.
-    pub async fn init_transition(&mut self, elder_state: ElderState) -> Result<Vec<NetworkDuty>> {
-        self.section_funds
-            .init_transition(elder_state)
-            .await
-            .convert()
+    pub async fn init_transition(&mut self, elder_state: ElderState) -> Result<NetworkDuties> {
+        Ok(NetworkDuties::from(
+            self.section_funds.init_transition(elder_state).await?,
+        ))
     }
 
-    pub async fn process_reward_duty(&mut self, duty: RewardDuty) -> Result<Vec<NetworkDuty>> {
+    pub async fn process_reward_duty(&mut self, duty: RewardDuty) -> Result<NetworkDuties> {
         use RewardDuty::*;
         match duty {
             ProcessCmd {
@@ -139,7 +137,7 @@ impl Rewards {
         cmd: RewardCmd,
         _msg_id: MessageId,
         _origin: SrcLocation,
-    ) -> Result<Vec<NetworkDuty>> {
+    ) -> Result<NetworkDuties> {
         use RewardCmd::*;
         let result = match cmd {
             InitiateSectionWallet(info) => {
@@ -180,7 +178,7 @@ impl Rewards {
         query: RewardQuery,
         msg_id: MessageId,
         origin: SrcLocation,
-    ) -> Result<Vec<NetworkDuty>> {
+    ) -> Result<NetworkDuties> {
         use RewardQuery::*;
         let result = match query {
             GetNodeWalletId {
@@ -197,8 +195,8 @@ impl Rewards {
     }
 
     /// On section splits, we are paying out to Elders.
-    pub async fn payout_rewards(&mut self, node_ids: BTreeSet<&XorName>) -> Result<Vec<NetworkDuty>> {
-        let mut payouts: Vec<Vec<NetworkDuty>> = vec![];
+    pub async fn payout_rewards(&mut self, node_ids: BTreeSet<&XorName>) -> Result<NetworkDuties> {
+        let mut payouts: NetworkDuties = vec![];
         for node_id in node_ids {
             // Try get the wallet..
             let (wallet, age) = match self.node_rewards.get(node_id) {
@@ -234,7 +232,7 @@ impl Rewards {
             payouts.push(payout.into());
         }
 
-        Ok(payouts.into())
+        Ok(payouts)
     }
 
     ///

--- a/src/node/elder_duties/data_section/rewards/section_funds.rs
+++ b/src/node/elder_duties/data_section/rewards/section_funds.rs
@@ -10,7 +10,7 @@ use super::validator::Validator;
 use crate::{
     node::{
         elder_duties::data_section::ElderSigning,
-        node_ops::{NodeMessagingDuty,  OutgoingMsg},
+        node_ops::{NetworkDuties, NodeMessagingDuty, OutgoingMsg},
     },
     ElderState, Error, Result,
 };
@@ -253,7 +253,7 @@ impl SectionFunds {
     /// As all Replicas have accumulated the distributed
     /// actor cmds and applied them, they'll send out the
     /// result, which each actor instance accumulates locally.
-    pub async fn receive(&mut self, validation: TransferValidated) -> Result<Vec<NetworkDuty>> {
+    pub async fn receive(&mut self, validation: TransferValidated) -> Result<NetworkDuties> {
         use NodeCmd::*;
         use NodeTransferCmd::*;
         if let Some(event) = self.actor.receive(validation)? {
@@ -282,13 +282,13 @@ impl SectionFunds {
             // If there are queued payouts,
             // the first in queue will be executed.
             // (NB: If we were transitioning, we cannot do this until Transfers has transitioned as well!)
-            let mut queued_op = vec![];
+            let mut queued_ops = vec![];
             if !transitioned {
-                queued_op = self.try_pop_queue().await?;
+                queued_ops = self.try_pop_queue().await?;
             }
 
             // We ask of our Replicas to register this transfer.
-            let reg_op = NodeMessagingDuty::Send(OutgoingMsg {
+            let mut register_op = NetworkDuties::from(NodeMessagingDuty::Send(OutgoingMsg {
                 msg: NodeMessage::NodeCmd {
                     cmd: Transfers(RegisterSectionPayout(proof)),
                     id: MessageId::new(),
@@ -296,12 +296,12 @@ impl SectionFunds {
                 .into(),
                 dst: DstLocation::Section(self.actor.id().into()),
                 to_be_aggregated: false, // TODO: aggregate here (not needed, but makes sn_node logs less chatty..)
-            })
-            .into();
+            }));
 
             // First register the transfer, then
             // carry out the first queued payout.
-            Ok(vec![reg_op, queued_op].into())
+            register_op.extend(queued_ops);
+            Ok(register_op)
         } else {
             Ok(vec![])
         }
@@ -309,7 +309,7 @@ impl SectionFunds {
 
     // Can safely be called without overwriting any
     // payout in flight, since validations for that are made.
-    async fn try_pop_queue(&mut self) -> Result<Vec<NetworkDuty>> {
+    async fn try_pop_queue(&mut self) -> Result<NetworkDuties> {
         if let Some(payout) = self.state.queued_payouts.pop_front() {
             // Validation logic when inititating rewards prevents enqueueing a payout that is already
             // in the finished set. Therefore, calling initiate here cannot return None because of
@@ -326,7 +326,7 @@ impl SectionFunds {
                         self.state.queued_payouts.insert(0, payout);
                     }
                 }
-                op => return Ok(op.into()),
+                op => return Ok(NetworkDuties::from(op)),
             }
         }
 

--- a/src/node/elder_duties/data_section/rewards/section_funds.rs
+++ b/src/node/elder_duties/data_section/rewards/section_funds.rs
@@ -10,7 +10,7 @@ use super::validator::Validator;
 use crate::{
     node::{
         elder_duties::data_section::ElderSigning,
-        node_ops::{NodeMessagingDuty, NodeOperation, OutgoingMsg},
+        node_ops::{NodeMessagingDuty,  OutgoingMsg},
     },
     ElderState, Error, Result,
 };
@@ -253,7 +253,7 @@ impl SectionFunds {
     /// As all Replicas have accumulated the distributed
     /// actor cmds and applied them, they'll send out the
     /// result, which each actor instance accumulates locally.
-    pub async fn receive(&mut self, validation: TransferValidated) -> Result<NodeOperation> {
+    pub async fn receive(&mut self, validation: TransferValidated) -> Result<Vec<NetworkDuty>> {
         use NodeCmd::*;
         use NodeTransferCmd::*;
         if let Some(event) = self.actor.receive(validation)? {
@@ -262,7 +262,7 @@ impl SectionFunds {
             let proof = if let Some(proof) = event.proof {
                 proof
             } else {
-                return Ok(NodeOperation::NoOp);
+                return Ok(vec![]);
             };
 
             if let Some(event) = self.actor.register(proof.clone())? {
@@ -282,7 +282,7 @@ impl SectionFunds {
             // If there are queued payouts,
             // the first in queue will be executed.
             // (NB: If we were transitioning, we cannot do this until Transfers has transitioned as well!)
-            let mut queued_op = NodeOperation::NoOp;
+            let mut queued_op = vec![];
             if !transitioned {
                 queued_op = self.try_pop_queue().await?;
             }
@@ -303,13 +303,13 @@ impl SectionFunds {
             // carry out the first queued payout.
             Ok(vec![reg_op, queued_op].into())
         } else {
-            Ok(NodeOperation::NoOp)
+            Ok(vec![])
         }
     }
 
     // Can safely be called without overwriting any
     // payout in flight, since validations for that are made.
-    async fn try_pop_queue(&mut self) -> Result<NodeOperation> {
+    async fn try_pop_queue(&mut self) -> Result<Vec<NetworkDuty>> {
         if let Some(payout) = self.state.queued_payouts.pop_front() {
             // Validation logic when inititating rewards prevents enqueueing a payout that is already
             // in the finished set. Therefore, calling initiate here cannot return None because of
@@ -330,7 +330,7 @@ impl SectionFunds {
             }
         }
 
-        Ok(NodeOperation::NoOp)
+        Ok(vec![])
     }
 
     /// Wallet transition, step 3.

--- a/src/node/elder_duties/key_section/mod.rs
+++ b/src/node/elder_duties/key_section/mod.rs
@@ -11,7 +11,7 @@ mod transfers;
 use self::transfers::{replica_signing::ReplicaSigning, replicas::Replicas, Transfers};
 use crate::{
     capacity::RateLimit,
-    node::node_ops::{KeySectionDuty, NodeOperation},
+    node::node_ops::{KeySectionDuty, NetworkDuties},
     ElderState, NodeInfo, Result,
 };
 use log::{info, trace};
@@ -74,12 +74,12 @@ impl KeySection {
     /// Issues queries to Elders of the section
     /// as to catch up with shares state and
     /// start working properly in the group.
-    pub async fn catchup_with_section(&mut self) -> Result<Vec<NetworkDuty>> {
+    pub async fn catchup_with_section(&mut self) -> Result<NetworkDuties> {
         // currently only at2 replicas need to catch up
         self.transfers.catchup_with_replicas().await
     }
 
-    pub async fn set_node_join_flag(&mut self, joins_allowed: bool) -> Result<Vec<NetworkDuty>> {
+    pub async fn set_node_join_flag(&mut self, joins_allowed: bool) -> Result<NetworkDuties> {
         match self.elder_state.set_joins_allowed(joins_allowed).await {
             Ok(()) => {
                 info!("Successfully set joins_allowed to true");
@@ -114,7 +114,7 @@ impl KeySection {
         self.transfers.split_section(prefix).await
     }
 
-    pub async fn process_key_section_duty(&self, duty: KeySectionDuty) -> Result<Vec<NetworkDuty>> {
+    pub async fn process_key_section_duty(&self, duty: KeySectionDuty) -> Result<NetworkDuties> {
         trace!("Processing as Elder KeySection");
         use KeySectionDuty::*;
         match duty {

--- a/src/node/elder_duties/key_section/mod.rs
+++ b/src/node/elder_duties/key_section/mod.rs
@@ -74,16 +74,16 @@ impl KeySection {
     /// Issues queries to Elders of the section
     /// as to catch up with shares state and
     /// start working properly in the group.
-    pub async fn catchup_with_section(&mut self) -> Result<NodeOperation> {
+    pub async fn catchup_with_section(&mut self) -> Result<Vec<NetworkDuty>> {
         // currently only at2 replicas need to catch up
         self.transfers.catchup_with_replicas().await
     }
 
-    pub async fn set_node_join_flag(&mut self, joins_allowed: bool) -> Result<NodeOperation> {
+    pub async fn set_node_join_flag(&mut self, joins_allowed: bool) -> Result<Vec<NetworkDuty>> {
         match self.elder_state.set_joins_allowed(joins_allowed).await {
             Ok(()) => {
                 info!("Successfully set joins_allowed to true");
-                Ok(NodeOperation::NoOp)
+                Ok(vec![])
             }
             Err(e) => Err(e),
         }
@@ -114,12 +114,12 @@ impl KeySection {
         self.transfers.split_section(prefix).await
     }
 
-    pub async fn process_key_section_duty(&self, duty: KeySectionDuty) -> Result<NodeOperation> {
+    pub async fn process_key_section_duty(&self, duty: KeySectionDuty) -> Result<Vec<NetworkDuty>> {
         trace!("Processing as Elder KeySection");
         use KeySectionDuty::*;
         match duty {
             RunAsTransfers(duty) => self.transfers.process_transfer_duty(&duty).await,
-            NoOp => Ok(NodeOperation::NoOp),
+            NoOp => Ok(vec![]),
         }
     }
 

--- a/src/node/elder_duties/key_section/transfers/mod.rs
+++ b/src/node/elder_duties/key_section/transfers/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     capacity::RateLimit,
     error::{convert_dt_error_to_error_message, convert_to_error_message},
     node::node_ops::{
-        IntoNodeOp, NodeMessagingDuty,  OutgoingMsg, TransferCmd, TransferDuty,
+        NetworkDuties, NetworkDuty, NodeMessagingDuty, OutgoingMsg, TransferCmd, TransferDuty,
         TransferQuery,
     },
     utils, Error, Result,
@@ -102,11 +102,11 @@ impl Transfers {
     /// Issues a query to existing Replicas
     /// asking for their events, as to catch up and
     /// start working properly in the group.
-    pub async fn catchup_with_replicas(&self) -> Result<Vec<NetworkDuty>> {
+    pub async fn catchup_with_replicas(&self) -> Result<NetworkDuties> {
         info!("Transfers: Catching up with transfer Replicas!");
         // prepare replica init
         let pub_key = PublicKey::Bls(self.replicas.replicas_pk_set().public_key());
-        Ok(NodeMessagingDuty::Send(OutgoingMsg {
+        Ok(NetworkDuties::from(NodeMessagingDuty::Send(OutgoingMsg {
             msg: NodeMessage::NodeQuery {
                 query: NodeQuery::Transfers(NodeTransferQuery::GetReplicaEvents),
                 id: MessageId::new(),
@@ -114,8 +114,7 @@ impl Transfers {
             .into(),
             dst: DstLocation::Section(pub_key.into()),
             to_be_aggregated: false,
-        })
-        .into())
+        })))
     }
 
     /// When section splits, the Replicas in either resulting section
@@ -134,7 +133,7 @@ impl Transfers {
 
     /// When handled by Elders in the dst
     /// section, the actual business logic is executed.
-    pub async fn process_transfer_duty(&self, duty: &TransferDuty) -> Result<Vec<NetworkDuty>> {
+    pub async fn process_transfer_duty(&self, duty: &TransferDuty) -> Result<NetworkDuties> {
         trace!("Processing transfer duty");
         use TransferDuty::*;
         match duty {
@@ -157,27 +156,29 @@ impl Transfers {
         query: &TransferQuery,
         msg_id: MessageId,
         origin: SrcLocation,
-    ) -> Result<Vec<NetworkDuty>> {
+    ) -> Result<NetworkDuties> {
         use TransferQuery::*;
-        let result = match query {
+        let duty = match query {
             GetNewSectionWallet(wallet_id) => {
                 self.get_new_section_wallet(*wallet_id, msg_id, origin)
-                    .await
+                    .await?
             }
-            GetReplicaEvents => self.all_events(msg_id, origin).await,
-            GetReplicaKeys(_wallet_id) => self.get_replica_pks(msg_id, origin).await,
-            GetBalance(wallet_id) => self.balance(*wallet_id, msg_id, origin).await,
+            GetReplicaEvents => self.all_events(msg_id, origin).await?,
+            GetReplicaKeys(_wallet_id) => self.get_replica_pks(msg_id, origin).await?,
+            GetBalance(wallet_id) => self.balance(*wallet_id, msg_id, origin).await?,
             GetHistory { at, since_version } => {
-                self.history(at, *since_version, msg_id, origin).await
+                self.history(at, *since_version, msg_id, origin).await?
             }
             GetStoreCost { bytes, .. } => {
                 let mut ops = vec![];
-                ops.push(self.get_store_cost(*bytes, msg_id, origin).await.convert());
+                ops.push(NetworkDuty::from(
+                    self.get_store_cost(*bytes, msg_id, origin).await?,
+                ));
                 //ops.push(Ok(ElderDuty::SwitchNodeJoin(self.rate_limit.check_network_storage().await).into()));
-                return Ok(ops.into());
+                return Ok(ops);
             }
         };
-        result.convert()
+        Ok(NetworkDuties::from(duty))
     }
 
     async fn process_cmd(
@@ -185,23 +186,26 @@ impl Transfers {
         cmd: &TransferCmd,
         msg_id: MessageId,
         origin: SrcLocation,
-    ) -> Result<Vec<NetworkDuty>> {
+    ) -> Result<NetworkDuties> {
         use TransferCmd::*;
         debug!("Processing cmd in Transfers mod");
-        let result = match cmd {
-            InitiateReplica(events) => self.initiate_replica(events).await,
-            ProcessPayment(msg) => self.process_payment(msg, origin).await,
+        let duty = match cmd {
+            InitiateReplica(events) => self.initiate_replica(events).await?,
+            ProcessPayment(msg) => self.process_payment(msg, origin).await?,
             #[cfg(feature = "simulated-payouts")]
             // Cmd to simulate a farming payout
-            SimulatePayout(transfer) => self.replicas.credit_without_proof(transfer.clone()).await,
+            SimulatePayout(transfer) => {
+                self.replicas.credit_without_proof(transfer.clone()).await?
+            }
             ValidateTransfer(signed_transfer) => {
-                self.validate(signed_transfer.clone(), msg_id, origin).await
+                self.validate(signed_transfer.clone(), msg_id, origin)
+                    .await?
             }
             ValidateSectionPayout(signed_transfer) => {
                 self.validate_section_payout(signed_transfer.clone(), msg_id, origin)
-                    .await
+                    .await?
             }
-            RegisterTransfer(debit_agreement) => self.register(&debit_agreement, msg_id).await,
+            RegisterTransfer(debit_agreement) => self.register(&debit_agreement, msg_id).await?,
             RegisterSectionPayout(debit_agreement) => {
                 return self
                     .register_section_payout(&debit_agreement, msg_id, origin)
@@ -209,10 +213,10 @@ impl Transfers {
             }
             PropagateTransfer(debit_agreement) => {
                 self.receive_propagated(&debit_agreement, msg_id, origin)
-                    .await
+                    .await?
             }
         };
-        result.convert()
+        Ok(NetworkDuties::from(duty))
     }
 
     ///
@@ -657,12 +661,12 @@ impl Transfers {
         proof: &TransferAgreementProof,
         msg_id: MessageId,
         origin: SrcLocation,
-    ) -> Result<Vec<NetworkDuty>> {
+    ) -> Result<NetworkDuties> {
         use NodeCmd::*;
         use NodeEvent::*;
         match self.replicas.register(proof).await {
             Ok(event) => {
-                let mut ops: Vec<Vec<NetworkDuty>> = vec![];
+                let mut ops: NetworkDuties = vec![];
                 // notify sending section
                 let location = event.transfer_proof.sender().into();
                 ops.push(
@@ -697,11 +701,11 @@ impl Transfers {
                     })
                     .into(),
                 );
-                Ok(ops.into())
+                Ok(ops)
             }
             Err(e) => {
                 let message_error = convert_to_error_message(e)?;
-                Ok(NodeMessagingDuty::Send(OutgoingMsg {
+                Ok(NetworkDuties::from(NodeMessagingDuty::Send(OutgoingMsg {
                     msg: NodeMessage::NodeCmdError {
                         error: NodeCmdError::Transfers(
                             NodeTransferError::SectionPayoutRegistration(message_error),
@@ -713,8 +717,7 @@ impl Transfers {
                     .into(),
                     dst: origin.to_dst(),
                     to_be_aggregated: true,
-                })
-                .into())
+                })))
             }
         }
     }

--- a/src/node/elder_duties/key_section/transfers/mod.rs
+++ b/src/node/elder_duties/key_section/transfers/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     capacity::RateLimit,
     error::{convert_dt_error_to_error_message, convert_to_error_message},
     node::node_ops::{
-        IntoNodeOp, NodeMessagingDuty, NodeOperation, OutgoingMsg, TransferCmd, TransferDuty,
+        IntoNodeOp, NodeMessagingDuty,  OutgoingMsg, TransferCmd, TransferDuty,
         TransferQuery,
     },
     utils, Error, Result,
@@ -102,7 +102,7 @@ impl Transfers {
     /// Issues a query to existing Replicas
     /// asking for their events, as to catch up and
     /// start working properly in the group.
-    pub async fn catchup_with_replicas(&self) -> Result<NodeOperation> {
+    pub async fn catchup_with_replicas(&self) -> Result<Vec<NetworkDuty>> {
         info!("Transfers: Catching up with transfer Replicas!");
         // prepare replica init
         let pub_key = PublicKey::Bls(self.replicas.replicas_pk_set().public_key());
@@ -134,7 +134,7 @@ impl Transfers {
 
     /// When handled by Elders in the dst
     /// section, the actual business logic is executed.
-    pub async fn process_transfer_duty(&self, duty: &TransferDuty) -> Result<NodeOperation> {
+    pub async fn process_transfer_duty(&self, duty: &TransferDuty) -> Result<Vec<NetworkDuty>> {
         trace!("Processing transfer duty");
         use TransferDuty::*;
         match duty {
@@ -148,7 +148,7 @@ impl Transfers {
                 msg_id,
                 origin,
             } => self.process_cmd(cmd, *msg_id, *origin).await,
-            NoOp => Ok(NodeOperation::NoOp),
+            NoOp => Ok(vec![]),
         }
     }
 
@@ -157,7 +157,7 @@ impl Transfers {
         query: &TransferQuery,
         msg_id: MessageId,
         origin: SrcLocation,
-    ) -> Result<NodeOperation> {
+    ) -> Result<Vec<NetworkDuty>> {
         use TransferQuery::*;
         let result = match query {
             GetNewSectionWallet(wallet_id) => {
@@ -185,7 +185,7 @@ impl Transfers {
         cmd: &TransferCmd,
         msg_id: MessageId,
         origin: SrcLocation,
-    ) -> Result<NodeOperation> {
+    ) -> Result<Vec<NetworkDuty>> {
         use TransferCmd::*;
         debug!("Processing cmd in Transfers mod");
         let result = match cmd {
@@ -657,12 +657,12 @@ impl Transfers {
         proof: &TransferAgreementProof,
         msg_id: MessageId,
         origin: SrcLocation,
-    ) -> Result<NodeOperation> {
+    ) -> Result<Vec<NetworkDuty>> {
         use NodeCmd::*;
         use NodeEvent::*;
         match self.replicas.register(proof).await {
             Ok(event) => {
-                let mut ops: Vec<NodeOperation> = vec![];
+                let mut ops: Vec<Vec<NetworkDuty>> = vec![];
                 // notify sending section
                 let location = event.transfer_proof.sender().into();
                 ops.push(

--- a/src/node/elder_duties/mod.rs
+++ b/src/node/elder_duties/mod.rs
@@ -12,7 +12,7 @@ mod key_section;
 use self::{data_section::DataSection, key_section::KeySection};
 use crate::{
     capacity::{Capacity, ChunkHolderDbs, RateLimit},
-    node::node_ops::{ElderDuty, NodeOperation},
+    node::node_ops::{ElderDuty, },
     ElderState, NodeInfo, Result,
 };
 use log::trace;
@@ -53,7 +53,7 @@ impl ElderDuties {
     /// Issues queries to Elders of the section
     /// as to catch up with shares state and
     /// start working properly in the group.
-    pub async fn initiate(&mut self, genesis: Option<TransferPropagated>) -> Result<NodeOperation> {
+    pub async fn initiate(&mut self, genesis: Option<TransferPropagated>) -> Result<Vec<NetworkDuty>> {
         let mut ops = vec![];
         if let Some(genesis) = genesis {
             // if we are genesis
@@ -68,7 +68,7 @@ impl ElderDuties {
     }
 
     /// Processing of any Elder duty.
-    pub async fn process_elder_duty(&mut self, duty: ElderDuty) -> Result<NodeOperation> {
+    pub async fn process_elder_duty(&mut self, duty: ElderDuty) -> Result<Vec<NetworkDuty>> {
         trace!("Processing elder duty: {:?}", duty);
         use ElderDuty::*;
         match duty {
@@ -92,20 +92,20 @@ impl ElderDuties {
             SwitchNodeJoin(joins_allowed) => {
                 self.key_section.set_node_join_flag(joins_allowed).await
             }
-            NoOp => Ok(NodeOperation::NoOp),
+            NoOp => Ok(vec![]),
         }
     }
 
     ///
-    async fn new_node_joined(&mut self, name: XorName) -> Result<NodeOperation> {
+    async fn new_node_joined(&mut self, name: XorName) -> Result<Vec<NetworkDuty>> {
         self.data_section.new_node_joined(name).await
     }
 
-    async fn increase_full_node_count(&mut self, node_id: PublicKey) -> Result<NodeOperation> {
+    async fn increase_full_node_count(&mut self, node_id: PublicKey) -> Result<Vec<NetworkDuty>> {
         self.key_section
             .increase_full_node_count(node_id)
             .await
-            .map(|()| NodeOperation::NoOp)
+            .map(|()| vec![])
     }
 
     ///
@@ -114,14 +114,14 @@ impl ElderDuties {
         old_node_id: XorName,
         new_node_id: XorName,
         age: u8,
-    ) -> Result<NodeOperation> {
+    ) -> Result<Vec<NetworkDuty>> {
         self.data_section
             .relocated_node_joined(old_node_id, new_node_id, age)
             .await
     }
 
     ///
-    async fn member_left(&mut self, node_id: XorName, age: u8) -> Result<NodeOperation> {
+    async fn member_left(&mut self, node_id: XorName, age: u8) -> Result<Vec<NetworkDuty>> {
         self.data_section.member_left(node_id, age).await
     }
 
@@ -129,7 +129,7 @@ impl ElderDuties {
     pub async fn initiate_elder_change(
         &mut self,
         elder_state: ElderState,
-    ) -> Result<NodeOperation> {
+    ) -> Result<Vec<NetworkDuty>> {
         // 1. First we must update data section..
         self.data_section.initiate_elder_change(elder_state).await
     }
@@ -148,7 +148,7 @@ impl ElderDuties {
     }
 
     ///
-    pub async fn split_section(&mut self, prefix: Prefix) -> Result<NodeOperation> {
+    pub async fn split_section(&mut self, prefix: Prefix) -> Result<Vec<NetworkDuty>> {
         let _ = self.key_section.split_section(prefix).await?;
         self.data_section.split_section(prefix).await
     }

--- a/src/node/elder_duties/mod.rs
+++ b/src/node/elder_duties/mod.rs
@@ -12,7 +12,7 @@ mod key_section;
 use self::{data_section::DataSection, key_section::KeySection};
 use crate::{
     capacity::{Capacity, ChunkHolderDbs, RateLimit},
-    node::node_ops::{ElderDuty, },
+    node::node_ops::{ElderDuty, NetworkDuties, NetworkDuty},
     ElderState, NodeInfo, Result,
 };
 use log::trace;
@@ -53,22 +53,22 @@ impl ElderDuties {
     /// Issues queries to Elders of the section
     /// as to catch up with shares state and
     /// start working properly in the group.
-    pub async fn initiate(&mut self, genesis: Option<TransferPropagated>) -> Result<Vec<NetworkDuty>> {
+    pub async fn initiate(&mut self, genesis: Option<TransferPropagated>) -> Result<NetworkDuties> {
         let mut ops = vec![];
         if let Some(genesis) = genesis {
             // if we are genesis
             // does local init, with no roundrip via network messaging
             let _ = self.key_section.init_genesis_node(genesis).await?;
         } else {
-            ops.push(self.key_section.catchup_with_section().await?);
-            ops.push(self.data_section.catchup_with_section().await?);
+            ops.append(&mut self.key_section.catchup_with_section().await?);
+            ops.append(&mut self.data_section.catchup_with_section().await?);
         }
 
-        Ok(ops.into())
+        Ok(ops)
     }
 
     /// Processing of any Elder duty.
-    pub async fn process_elder_duty(&mut self, duty: ElderDuty) -> Result<Vec<NetworkDuty>> {
+    pub async fn process_elder_duty(&mut self, duty: ElderDuty) -> Result<NetworkDuties> {
         trace!("Processing elder duty: {:?}", duty);
         use ElderDuty::*;
         match duty {
@@ -97,11 +97,11 @@ impl ElderDuties {
     }
 
     ///
-    async fn new_node_joined(&mut self, name: XorName) -> Result<Vec<NetworkDuty>> {
+    async fn new_node_joined(&mut self, name: XorName) -> Result<NetworkDuties> {
         self.data_section.new_node_joined(name).await
     }
 
-    async fn increase_full_node_count(&mut self, node_id: PublicKey) -> Result<Vec<NetworkDuty>> {
+    async fn increase_full_node_count(&mut self, node_id: PublicKey) -> Result<NetworkDuties> {
         self.key_section
             .increase_full_node_count(node_id)
             .await
@@ -114,14 +114,14 @@ impl ElderDuties {
         old_node_id: XorName,
         new_node_id: XorName,
         age: u8,
-    ) -> Result<Vec<NetworkDuty>> {
+    ) -> Result<NetworkDuties> {
         self.data_section
             .relocated_node_joined(old_node_id, new_node_id, age)
             .await
     }
 
     ///
-    async fn member_left(&mut self, node_id: XorName, age: u8) -> Result<Vec<NetworkDuty>> {
+    async fn member_left(&mut self, node_id: XorName, age: u8) -> Result<NetworkDuties> {
         self.data_section.member_left(node_id, age).await
     }
 
@@ -129,7 +129,7 @@ impl ElderDuties {
     pub async fn initiate_elder_change(
         &mut self,
         elder_state: ElderState,
-    ) -> Result<Vec<NetworkDuty>> {
+    ) -> Result<NetworkDuties> {
         // 1. First we must update data section..
         self.data_section.initiate_elder_change(elder_state).await
     }
@@ -148,7 +148,7 @@ impl ElderDuties {
     }
 
     ///
-    pub async fn split_section(&mut self, prefix: Prefix) -> Result<Vec<NetworkDuty>> {
+    pub async fn split_section(&mut self, prefix: Prefix) -> Result<NetworkDuties> {
         let _ = self.key_section.split_section(prefix).await?;
         self.data_section.split_section(prefix).await
     }

--- a/src/node/elder_duties/mod.rs
+++ b/src/node/elder_duties/mod.rs
@@ -12,7 +12,7 @@ mod key_section;
 use self::{data_section::DataSection, key_section::KeySection};
 use crate::{
     capacity::{Capacity, ChunkHolderDbs, RateLimit},
-    node::node_ops::{ElderDuty, NetworkDuties, NetworkDuty},
+    node::node_ops::{ElderDuty, NetworkDuties},
     ElderState, NodeInfo, Result,
 };
 use log::trace;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -160,7 +160,7 @@ impl Node {
         while let Ok(ops) = next_ops {
             let mut pending_node_ops = Vec::new();
 
-            if ops.len() > 0 {
+            if !ops.is_empty() {
                 for duty in ops {
                     match self.process(duty).await {
                         Ok(new_ops) => pending_node_ops.extend(new_ops),

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     chunk_store::UsedSpace,
     node::{
         node_duties::NodeDuties,
-        node_ops::{NetworkDuty, NodeDuty, NodeOperation},
+        node_ops::{NetworkDuty, NodeDuty},
         state_db::{get_age_group, store_age_group, store_new_reward_keypair, AgeGroup},
     },
     Config, Error, Network, NodeInfo, Result,
@@ -84,6 +84,7 @@ impl Node {
         use AgeGroup::*;
         let age = network_api.age().await;
         info!("Our Age: {:?}", age);
+        info!("Is genesis: {:?}", node_info.genesis);
 
         info!("Fetching Age bracket");
         let age_group = if !network_api.is_elder().await && age > MIN_AGE {
@@ -96,7 +97,7 @@ impl Node {
 
         let mut duties = NodeDuties::new(node_info, network_api.clone()).await?;
         let next_duty = match age_group {
-            Infant => Ok(NodeOperation::NoOp),
+            Infant => Ok(vec![]),
             Adult => {
                 info!("Starting as Adult");
                 duties
@@ -143,7 +144,7 @@ impl Node {
         info!("Listening for routing events at: {}", info);
         while let Some(event) = self.network_events.next().await {
             info!("New event received from the Network: {:?}", event);
-            self.process_while_any(Ok(NodeDuty::ProcessNetworkEvent(event).into()))
+            self.process_while_any(Ok(vec![NodeDuty::ProcessNetworkEvent(event)]))
                 .await;
         }
 
@@ -151,35 +152,27 @@ impl Node {
     }
 
     /// Keeps processing resulting node operations.
-    async fn process_while_any(&mut self, op: Result<NodeOperation>) {
-        use NodeOperation::*;
-        let mut next_op = op;
-        while let Ok(op) = next_op {
-            next_op = match op {
-                Single(operation) => match self.process(operation).await {
-                    Err(e) => {
-                        self.handle_error(&e);
-                        Ok(NoOp)
-                    }
-                    result => result,
-                },
-                Multiple(ops) => {
-                    let mut node_ops = Vec::new();
-                    for c in ops.into_iter() {
-                        match self.process(c).await {
-                            Ok(NoOp) => (),
-                            Ok(op) => node_ops.push(op),
-                            Err(e) => self.handle_error(&e),
-                        };
-                    }
-                    Ok(node_ops.into())
+    async fn process_while_any(&mut self, ops_vec: Result<Vec<NetworkDuty>>) {
+        let mut next_ops = ops_vec;
+
+        while let Ok(ops) = next_ops {
+            let mut pending_node_ops = Vec::new();
+
+            if ops.len() > 0 {
+                for duty in ops {
+                    match self.process(duty).await {
+                        Ok(new_ops) => pending_node_ops.extend(new_ops),
+                        Err(e) => self.handle_error(&e),
+                    };
                 }
-                NoOp => break,
+                next_ops = Ok(pending_node_ops);
+            } else {
+                break;
             }
         }
     }
 
-    async fn process(&mut self, duty: NetworkDuty) -> Result<NodeOperation> {
+    async fn process(&mut self, duty: NetworkDuty) -> Result<Vec<NetworkDuty>> {
         use NetworkDuty::*;
         match duty {
             RunAsAdult(duty) => {
@@ -195,14 +188,14 @@ impl Node {
                     duties.process_elder_duty(duty).await
                 } else if self.duties.try_enqueue_elder_duty(duty) {
                     info!("Enqueued Elder duty");
-                    Ok(NodeOperation::NoOp)
+                    Ok(vec![])
                 } else {
                     error!("Currently not an Elder!");
                     Err(Error::Logic("Currently not an Elder".to_string()))
                 }
             }
             RunAsNode(duty) => self.duties.process_node_duty(duty).await,
-            NoOp => Ok(NodeOperation::NoOp),
+            NoOp => Ok(vec![]),
         }
     }
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     chunk_store::UsedSpace,
     node::{
         node_duties::NodeDuties,
-        node_ops::{NetworkDuty, NodeDuty},
+        node_ops::{NetworkDuties, NetworkDuty, NodeDuty},
         state_db::{get_age_group, store_age_group, store_new_reward_keypair, AgeGroup},
     },
     Config, Error, Network, NodeInfo, Result,
@@ -144,15 +144,17 @@ impl Node {
         info!("Listening for routing events at: {}", info);
         while let Some(event) = self.network_events.next().await {
             info!("New event received from the Network: {:?}", event);
-            self.process_while_any(Ok(vec![NodeDuty::ProcessNetworkEvent(event)]))
-                .await;
+            self.process_while_any(Ok(NetworkDuties::from(NodeDuty::ProcessNetworkEvent(
+                event,
+            ))))
+            .await;
         }
 
         Ok(())
     }
 
     /// Keeps processing resulting node operations.
-    async fn process_while_any(&mut self, ops_vec: Result<Vec<NetworkDuty>>) {
+    async fn process_while_any(&mut self, ops_vec: Result<NetworkDuties>) {
         let mut next_ops = ops_vec;
 
         while let Ok(ops) = next_ops {
@@ -172,7 +174,7 @@ impl Node {
         }
     }
 
-    async fn process(&mut self, duty: NetworkDuty) -> Result<Vec<NetworkDuty>> {
+    async fn process(&mut self, duty: NetworkDuty) -> Result<NetworkDuties> {
         use NetworkDuty::*;
         match duty {
             RunAsAdult(duty) => {

--- a/src/node/node_duties/elder_constellation.rs
+++ b/src/node/node_duties/elder_constellation.rs
@@ -9,7 +9,7 @@
 use super::ElderDuties;
 use crate::{ElderState, Network, NodeInfo, Result};
 
-use crate::{node::node_ops:: Error};
+use crate::{node::node_ops::NetworkDuties, Error};
 use log::{debug, info};
 use sn_data_types::PublicKey;
 use sn_routing::Prefix;
@@ -55,7 +55,7 @@ impl ElderConstellation {
         &mut self,
         prefix: Prefix,
         new_section_key: PublicKey,
-    ) -> Result<Vec<NetworkDuty>> {
+    ) -> Result<NetworkDuties> {
         let elder_state = self.duties.state();
 
         if new_section_key == elder_state.section_public_key()
@@ -92,7 +92,7 @@ impl ElderConstellation {
         node_info: &NodeInfo,
         previous_key: PublicKey,
         new_key: PublicKey,
-    ) -> Result<Vec<NetworkDuty>> {
+    ) -> Result<NetworkDuties> {
         if new_key == previous_key {
             return Err(Error::InvalidOperation(
                 "new_key == previous_key".to_string(),
@@ -108,7 +108,7 @@ impl ElderConstellation {
             return Ok(vec![]);
         }
 
-        let mut ops = Vec::new();
+        let mut ops: NetworkDuties = Vec::new();
         // pop the pending change..
         let change = self.pending_changes.remove(0);
 
@@ -129,21 +129,21 @@ impl ElderConstellation {
         if &change.prefix != old_elder_state.prefix() {
             info!("Split occurred");
             info!("New prefix is: {:?}", change.prefix);
-            match self.duties.split_section(change.prefix).await? {
-                vec![] => (),
-                op => ops.push(op),
+            let duties = self.duties.split_section(change.prefix).await?;
+            if duties.len() > 0 {
+                ops.extend(duties)
             };
         }
 
         // if changes have queued up, make sure the queue is worked down
         if !self.pending_changes.is_empty() {
             let change = self.pending_changes.remove(0);
-            ops.push(
+            ops.extend(
                 self.initiate_elder_change(change.prefix, change.section_key)
                     .await?,
             );
         }
 
-        Ok(ops.into())
+        Ok(ops)
     }
 }

--- a/src/node/node_duties/elder_constellation.rs
+++ b/src/node/node_duties/elder_constellation.rs
@@ -9,7 +9,7 @@
 use super::ElderDuties;
 use crate::{ElderState, Network, NodeInfo, Result};
 
-use crate::{node::node_ops::NodeOperation, Error};
+use crate::{node::node_ops:: Error};
 use log::{debug, info};
 use sn_data_types::PublicKey;
 use sn_routing::Prefix;
@@ -55,7 +55,7 @@ impl ElderConstellation {
         &mut self,
         prefix: Prefix,
         new_section_key: PublicKey,
-    ) -> Result<NodeOperation> {
+    ) -> Result<Vec<NetworkDuty>> {
         let elder_state = self.duties.state();
 
         if new_section_key == elder_state.section_public_key()
@@ -64,7 +64,7 @@ impl ElderConstellation {
                 .iter()
                 .any(|c| c.section_key == new_section_key)
         {
-            return Ok(NodeOperation::NoOp);
+            return Ok(vec![]);
         }
 
         info!("Elder change updates initiated");
@@ -76,7 +76,7 @@ impl ElderConstellation {
 
         // handle changes sequentially
         if self.pending_changes.len() > 1 {
-            return Ok(NodeOperation::NoOp);
+            return Ok(vec![]);
         }
 
         // 1. First we must update data section..
@@ -92,20 +92,20 @@ impl ElderConstellation {
         node_info: &NodeInfo,
         previous_key: PublicKey,
         new_key: PublicKey,
-    ) -> Result<NodeOperation> {
+    ) -> Result<Vec<NetworkDuty>> {
         if new_key == previous_key {
             return Err(Error::InvalidOperation(
                 "new_key == previous_key".to_string(),
             ));
         }
         if self.pending_changes.is_empty() {
-            return Ok(NodeOperation::NoOp);
+            return Ok(vec![]);
         }
         let old_elder_state = self.duties.state().clone();
         if old_elder_state.section_public_key() != previous_key
             || new_key != self.pending_changes[0].section_key
         {
-            return Ok(NodeOperation::NoOp);
+            return Ok(vec![]);
         }
 
         let mut ops = Vec::new();
@@ -130,7 +130,7 @@ impl ElderConstellation {
             info!("Split occurred");
             info!("New prefix is: {:?}", change.prefix);
             match self.duties.split_section(change.prefix).await? {
-                NodeOperation::NoOp => (),
+                vec![] => (),
                 op => ops.push(op),
             };
         }

--- a/src/node/node_duties/elder_constellation.rs
+++ b/src/node/node_duties/elder_constellation.rs
@@ -130,7 +130,7 @@ impl ElderConstellation {
             info!("Split occurred");
             info!("New prefix is: {:?}", change.prefix);
             let duties = self.duties.split_section(change.prefix).await?;
-            if duties.len() > 0 {
+            if !duties.is_empty() {
                 ops.extend(duties)
             };
         }

--- a/src/node/node_duties/messaging.rs
+++ b/src/node/node_duties/messaging.rs
@@ -9,7 +9,7 @@
 use std::collections::BTreeSet;
 
 use crate::{
-    node::node_ops::{NodeMessagingDuty,  OutgoingMsg},
+    node::node_ops::{NetworkDuties, NodeMessagingDuty, OutgoingMsg},
     Error,
 };
 use crate::{Network, Result};
@@ -32,7 +32,7 @@ impl Messaging {
     pub async fn process_messaging_duty(
         &mut self,
         duty: NodeMessagingDuty,
-    ) -> Result<Vec<NetworkDuty>> {
+    ) -> Result<NetworkDuties> {
         use NodeMessagingDuty::*;
         match duty {
             Send(msg) => self.send(msg).await,
@@ -41,7 +41,7 @@ impl Messaging {
         }
     }
 
-    async fn send(&mut self, msg: OutgoingMsg) -> Result<Vec<NetworkDuty>> {
+    async fn send(&mut self, msg: OutgoingMsg) -> Result<NetworkDuties> {
         let src = if msg.to_be_aggregated {
             SrcLocation::Section(self.network.our_prefix().await)
         } else {
@@ -63,7 +63,7 @@ impl Messaging {
         &mut self,
         targets: BTreeSet<XorName>,
         msg: Message,
-    ) -> Result<Vec<NetworkDuty>> {
+    ) -> Result<NetworkDuties> {
         let name = self.network.our_name().await;
         for target in targets {
             self.network

--- a/src/node/node_duties/messaging.rs
+++ b/src/node/node_duties/messaging.rs
@@ -9,7 +9,7 @@
 use std::collections::BTreeSet;
 
 use crate::{
-    node::node_ops::{NodeMessagingDuty, NodeOperation, OutgoingMsg},
+    node::node_ops::{NodeMessagingDuty,  OutgoingMsg},
     Error,
 };
 use crate::{Network, Result};
@@ -32,16 +32,16 @@ impl Messaging {
     pub async fn process_messaging_duty(
         &mut self,
         duty: NodeMessagingDuty,
-    ) -> Result<NodeOperation> {
+    ) -> Result<Vec<NetworkDuty>> {
         use NodeMessagingDuty::*;
         match duty {
             Send(msg) => self.send(msg).await,
             SendToAdults { targets, msg } => self.send_to_nodes(targets, msg).await,
-            NoOp => Ok(NodeOperation::NoOp),
+            NoOp => Ok(vec![]),
         }
     }
 
-    async fn send(&mut self, msg: OutgoingMsg) -> Result<NodeOperation> {
+    async fn send(&mut self, msg: OutgoingMsg) -> Result<Vec<NetworkDuty>> {
         let src = if msg.to_be_aggregated {
             SrcLocation::Section(self.network.our_prefix().await)
         } else {
@@ -55,7 +55,7 @@ impl Messaging {
                 error!("Unable to send msg: {:?}", err);
                 Err(Error::Logic(format!("Unable to send msg: {:?}", id)))
             },
-            |()| Ok(NodeOperation::NoOp),
+            |()| Ok(vec![]),
         )
     }
 
@@ -63,7 +63,7 @@ impl Messaging {
         &mut self,
         targets: BTreeSet<XorName>,
         msg: Message,
-    ) -> Result<NodeOperation> {
+    ) -> Result<Vec<NetworkDuty>> {
         let name = self.network.our_name().await;
         for target in targets {
             self.network
@@ -80,6 +80,6 @@ impl Messaging {
                     |()| {},
                 );
         }
-        Ok(NodeOperation::NoOp)
+        Ok(vec![])
     }
 }

--- a/src/node/node_duties/mod.rs
+++ b/src/node/node_duties/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         adult_duties::AdultDuties,
         elder_duties::ElderDuties,
         node_duties::messaging::Messaging,
-        node_ops::{ElderDuty, NodeDuty, NodeOperation, OutgoingMsg, RewardCmd, RewardDuty},
+        node_ops::{ElderDuty, NodeDuty,  OutgoingMsg, RewardCmd, RewardDuty},
         NodeInfo,
     },
     AdultState, ElderState, Error, Network, NodeState, Result,
@@ -209,7 +209,7 @@ impl NodeDuties {
         })
     }
 
-    pub async fn process_node_duty(&mut self, duty: NodeDuty) -> Result<NodeOperation> {
+    pub async fn process_node_duty(&mut self, duty: NodeDuty) -> Result<Vec<NetworkDuty>> {
         use NodeDuty::*;
         info!("Processing Node duty: {:?}", duty);
         match duty {
@@ -238,13 +238,14 @@ impl NodeDuties {
                     .process_network_event(event, &self.network_api)
                     .await
             }
-            NoOp => Ok(NodeOperation::NoOp),
+            NoOp => Ok(vec![]),
             StorageFull => self.notify_section_of_our_storage().await,
         }
     }
 
-    async fn notify_section_of_our_storage(&mut self) -> Result<NodeOperation> {
+    async fn notify_section_of_our_storage(&mut self) -> Result<Vec<NetworkDuty>> {
         let node_id = PublicKey::from(self.network_api.public_key().await);
+        // let node_id = self.node_info.node_id;
         Ok(NodeMessagingDuty::Send(OutgoingMsg {
             msg: NodeMessage::NodeCmd {
                 cmd: NodeCmd::System(NodeSystemCmd::StorageFull {
@@ -260,7 +261,7 @@ impl NodeDuties {
         .into())
     }
 
-    async fn register_wallet(&mut self, wallet: PublicKey) -> Result<NodeOperation> {
+    async fn register_wallet(&mut self, wallet: PublicKey) -> Result<Vec<NetworkDuty>> {
         let node_state = self.node_state()?;
         info!("Registering wallet: {}", wallet);
         Ok(NodeMessagingDuty::Send(OutgoingMsg {
@@ -278,9 +279,9 @@ impl NodeDuties {
         .into())
     }
 
-    async fn assume_adult_duties(&mut self) -> Result<NodeOperation> {
+    async fn assume_adult_duties(&mut self) -> Result<Vec<NetworkDuty>> {
         if matches!(self.stage, Stage::Adult(_)) {
-            return Ok(NodeOperation::NoOp);
+            return Ok(vec![]);
         }
         info!("Assuming Adult duties..");
         let state = AdultState::new(self.network_api.clone()).await?;
@@ -296,12 +297,12 @@ impl NodeDuties {
         Ok(NodeDuty::RegisterWallet(self.node_info.reward_key).into())
     }
 
-    async fn begin_transition_to_elder(&mut self) -> Result<NodeOperation> {
+    async fn begin_transition_to_elder(&mut self) -> Result<Vec<NetworkDuty>> {
         if matches!(self.stage, Stage::Elder(_))
             || matches!(self.stage, Stage::AssumingElderDuties(_))
             || matches!(self.stage, Stage::AwaitingGenesisThreshold(_))
         {
-            return Ok(NodeOperation::NoOp);
+            return Ok(vec![]);
         } else if !self.node_info.genesis && matches!(self.stage, Stage::Infant) {
             return Err(Error::InvalidOperation(
                 "only genesis node can transition to Elder as Infant".to_string(),
@@ -358,7 +359,7 @@ impl NodeDuties {
         } else if is_genesis_section && elder_count < GENESIS_ELDER_COUNT {
             debug!("AwaitingGenesisThreshold!");
             self.stage = Stage::AwaitingGenesisThreshold(VecDeque::new());
-            return Ok(NodeOperation::NoOp);
+            return Ok(vec![]);
         }
 
         debug!("Beginning normal transition to Elder.");
@@ -380,7 +381,7 @@ impl NodeDuties {
             .into());
         }
 
-        Ok(NodeOperation::NoOp)
+        Ok(vec![])
     }
 
     // TODO: validate the credit...
@@ -388,11 +389,11 @@ impl NodeDuties {
         &mut self,
         credit: Credit,
         sig: SignatureShare,
-    ) -> Result<NodeOperation> {
+    ) -> Result<Vec<NetworkDuty>> {
         if matches!(self.stage, Stage::AccumulatingGenesis(_))
             || matches!(self.stage, Stage::Elder(_))
         {
-            return Ok(NodeOperation::NoOp);
+            return Ok(vec![]);
         }
 
         let (stage, cmd) = match self.stage {
@@ -466,7 +467,7 @@ impl NodeDuties {
 
                     (stage, cmd)
                 } else {
-                    return Ok(NodeOperation::NoOp);
+                    return Ok(vec![]);
                 }
             }
             _ => {
@@ -485,9 +486,9 @@ impl NodeDuties {
         &mut self,
         signed_credit: SignedCredit,
         sig: SignatureShare,
-    ) -> Result<NodeOperation> {
+    ) -> Result<Vec<NetworkDuty>> {
         if matches!(self.stage, Stage::Elder(_)) {
-            return Ok(NodeOperation::NoOp);
+            return Ok(vec![]);
         }
 
         match self.stage {
@@ -506,7 +507,7 @@ impl NodeDuties {
                     pending_agreement: None,
                     queued_ops: bootstrap.queued_ops.drain(..).collect(),
                 });
-                Ok(NodeOperation::NoOp)
+                Ok(vec![])
             }
             Stage::AccumulatingGenesis(ref mut bootstrap) => {
                 let _ = bootstrap.add(sig)?;
@@ -535,7 +536,7 @@ impl NodeDuties {
                         )
                         .await;
                 }
-                Ok(NodeOperation::NoOp)
+                Ok(vec![])
             }
             _ => Err(Error::InvalidOperation(
                 "invalid self.stage at fn receive_genesis_accumulation".to_string(),
@@ -547,10 +548,10 @@ impl NodeDuties {
         &mut self,
         wallet_info: WalletInfo,
         genesis: Option<TransferPropagated>,
-    ) -> Result<NodeOperation> {
+    ) -> Result<Vec<NetworkDuty>> {
         let queued_duties = &mut VecDeque::new();
         let queued_duties = match self.stage {
-            Stage::Elder(_) => return Ok(NodeOperation::NoOp),
+            Stage::Elder(_) => return Ok(vec![]),
             Stage::Infant => {
                 if self.node_info.genesis {
                     queued_duties
@@ -567,7 +568,7 @@ impl NodeDuties {
 
         trace!("Finishing transition to Elder..");
 
-        let mut ops: Vec<NodeOperation> = vec![];
+        let mut ops: Vec<Vec<NetworkDuty>> = vec![];
         let state = ElderState::new(self.network_api.clone()).await?;
         let mut duties = ElderDuties::new(wallet_info, &self.node_info, state.clone()).await?;
 
@@ -625,18 +626,18 @@ impl NodeDuties {
         &mut self,
         prefix: sn_routing::Prefix,
         new_section_key: PublicKey,
-    ) -> Result<NodeOperation> {
+    ) -> Result<Vec<NetworkDuty>> {
         match &mut self.stage {
-            Stage::Infant => Ok(NodeOperation::NoOp),
-            Stage::AssumingElderDuties(_) => Ok(NodeOperation::NoOp), // TODO: Queue up (or something?)!!
-            Stage::AwaitingGenesisThreshold(_) => Ok(NodeOperation::NoOp),
-            Stage::ProposingGenesis(_) => Ok(NodeOperation::NoOp), // TODO: Queue up (or something?)!!
-            Stage::AccumulatingGenesis(_) => Ok(NodeOperation::NoOp), // TODO: Queue up (or something?)!!
+            Stage::Infant => Ok(vec![]),
+            Stage::AssumingElderDuties(_) => Ok(vec![]), // TODO: Queue up (or something?)!!
+            Stage::AwaitingGenesisThreshold(_) => Ok(vec![]),
+            Stage::ProposingGenesis(_) => Ok(vec![]), // TODO: Queue up (or something?)!!
+            Stage::AccumulatingGenesis(_) => Ok(vec![]), // TODO: Queue up (or something?)!!
             Stage::Adult(_old_state) => {
                 let state = AdultState::new(self.network_api.clone()).await?;
                 let duties = AdultDuties::new(&self.node_info, state).await?;
                 self.stage = Stage::Adult(duties);
-                Ok(NodeOperation::NoOp)
+                Ok(vec![])
             }
             Stage::Elder(elder) => elder.initiate_elder_change(prefix, new_section_key).await,
         }
@@ -647,13 +648,13 @@ impl NodeDuties {
         &mut self,
         previous_key: PublicKey,
         new_key: PublicKey,
-    ) -> Result<NodeOperation> {
+    ) -> Result<Vec<NetworkDuty>> {
         match &mut self.stage {
-            Stage::AwaitingGenesisThreshold(_) => Ok(NodeOperation::NoOp),
-            Stage::ProposingGenesis(_) => Ok(NodeOperation::NoOp),
-            Stage::AccumulatingGenesis(_) => Ok(NodeOperation::NoOp),
-            Stage::AssumingElderDuties(_) => Ok(NodeOperation::NoOp), // Should be unreachable?
-            Stage::Infant | Stage::Adult(_) => Ok(NodeOperation::NoOp),
+            Stage::AwaitingGenesisThreshold(_) => Ok(vec![]),
+            Stage::ProposingGenesis(_) => Ok(vec![]),
+            Stage::AccumulatingGenesis(_) => Ok(vec![]),
+            Stage::AssumingElderDuties(_) => Ok(vec![]), // Should be unreachable?
+            Stage::Infant | Stage::Adult(_) => Ok(vec![]),
             Stage::Elder(elder) => {
                 elder
                     .finish_elder_change(&self.node_info, previous_key, new_key)

--- a/src/node/node_duties/mod.rs
+++ b/src/node/node_duties/mod.rs
@@ -17,7 +17,9 @@ use crate::{
         adult_duties::AdultDuties,
         elder_duties::ElderDuties,
         node_duties::messaging::Messaging,
-        node_ops::{ElderDuty, NodeDuty,  OutgoingMsg, RewardCmd, RewardDuty},
+        node_ops::{
+            ElderDuty, NetworkDuties, NetworkDuty, NodeDuty, OutgoingMsg, RewardCmd, RewardDuty,
+        },
         NodeInfo,
     },
     AdultState, ElderState, Error, Network, NodeState, Result,
@@ -209,7 +211,7 @@ impl NodeDuties {
         })
     }
 
-    pub async fn process_node_duty(&mut self, duty: NodeDuty) -> Result<Vec<NetworkDuty>> {
+    pub async fn process_node_duty(&mut self, duty: NodeDuty) -> Result<NetworkDuties> {
         use NodeDuty::*;
         info!("Processing Node duty: {:?}", duty);
         match duty {
@@ -243,10 +245,9 @@ impl NodeDuties {
         }
     }
 
-    async fn notify_section_of_our_storage(&mut self) -> Result<Vec<NetworkDuty>> {
+    async fn notify_section_of_our_storage(&mut self) -> Result<NetworkDuties> {
         let node_id = PublicKey::from(self.network_api.public_key().await);
-        // let node_id = self.node_info.node_id;
-        Ok(NodeMessagingDuty::Send(OutgoingMsg {
+        Ok(NetworkDuties::from(NodeMessagingDuty::Send(OutgoingMsg {
             msg: NodeMessage::NodeCmd {
                 cmd: NodeCmd::System(NodeSystemCmd::StorageFull {
                     section: node_id.into(),
@@ -257,14 +258,13 @@ impl NodeDuties {
             .into(),
             dst: DstLocation::Section(node_id.into()),
             to_be_aggregated: false,
-        })
-        .into())
+        })))
     }
 
-    async fn register_wallet(&mut self, wallet: PublicKey) -> Result<Vec<NetworkDuty>> {
+    async fn register_wallet(&mut self, wallet: PublicKey) -> Result<NetworkDuties> {
         let node_state = self.node_state()?;
         info!("Registering wallet: {}", wallet);
-        Ok(NodeMessagingDuty::Send(OutgoingMsg {
+        Ok(NetworkDuties::from(NodeMessagingDuty::Send(OutgoingMsg {
             msg: NodeMessage::NodeCmd {
                 cmd: NodeCmd::System(NodeSystemCmd::RegisterWallet {
                     wallet,
@@ -275,11 +275,10 @@ impl NodeDuties {
             .into(),
             dst: DstLocation::Section(wallet.into()),
             to_be_aggregated: false,
-        })
-        .into())
+        })))
     }
 
-    async fn assume_adult_duties(&mut self) -> Result<Vec<NetworkDuty>> {
+    async fn assume_adult_duties(&mut self) -> Result<NetworkDuties> {
         if matches!(self.stage, Stage::Adult(_)) {
             return Ok(vec![]);
         }
@@ -297,7 +296,7 @@ impl NodeDuties {
         Ok(NodeDuty::RegisterWallet(self.node_info.reward_key).into())
     }
 
-    async fn begin_transition_to_elder(&mut self) -> Result<Vec<NetworkDuty>> {
+    async fn begin_transition_to_elder(&mut self) -> Result<NetworkDuties> {
         if matches!(self.stage, Stage::Elder(_))
             || matches!(self.stage, Stage::AssumingElderDuties(_))
             || matches!(self.stage, Stage::AwaitingGenesisThreshold(_))
@@ -343,7 +342,7 @@ impl NodeDuties {
             });
 
             let dst = DstLocation::Section(credit.recipient.into());
-            return Ok(NodeMessagingDuty::Send(OutgoingMsg {
+            return Ok(NetworkDuties::from(NodeMessagingDuty::Send(OutgoingMsg {
                 msg: NodeMessage::NodeCmd {
                     cmd: NodeCmd::System(NodeSystemCmd::ProposeGenesis {
                         credit,
@@ -354,8 +353,7 @@ impl NodeDuties {
                 .into(),
                 dst,
                 to_be_aggregated: false,
-            })
-            .into());
+            })));
         } else if is_genesis_section && elder_count < GENESIS_ELDER_COUNT {
             debug!("AwaitingGenesisThreshold!");
             self.stage = Stage::AwaitingGenesisThreshold(VecDeque::new());
@@ -369,7 +367,7 @@ impl NodeDuties {
             // must get the above wrapping instance before overwriting stage
             self.stage = Stage::AssumingElderDuties(VecDeque::new());
             // queries the other Elders for the section wallet history
-            return Ok(NodeMessagingDuty::Send(OutgoingMsg {
+            return Ok(NetworkDuties::from(NodeMessagingDuty::Send(OutgoingMsg {
                 msg: NodeMessage::NodeQuery {
                     query: NodeQuery::Rewards(NodeRewardQuery::GetSectionWalletHistory),
                     id: MessageId::new(),
@@ -377,8 +375,7 @@ impl NodeDuties {
                 .into(),
                 dst: DstLocation::Section(wallet_id.into()),
                 to_be_aggregated: false,
-            })
-            .into());
+            })));
         }
 
         Ok(vec![])
@@ -389,7 +386,7 @@ impl NodeDuties {
         &mut self,
         credit: Credit,
         sig: SignatureShare,
-    ) -> Result<Vec<NetworkDuty>> {
+    ) -> Result<NetworkDuties> {
         if matches!(self.stage, Stage::AccumulatingGenesis(_))
             || matches!(self.stage, Stage::Elder(_))
         {
@@ -414,7 +411,7 @@ impl NodeDuties {
                     pending_agreement: None,
                     queued_ops: queued_ops.drain(..).collect(),
                 });
-                let cmd = Ok(NodeMessagingDuty::Send(OutgoingMsg {
+                let cmd = NodeMessagingDuty::Send(OutgoingMsg {
                     msg: NodeMessage::NodeCmd {
                         cmd: NodeCmd::System(NodeSystemCmd::ProposeGenesis {
                             credit,
@@ -425,8 +422,7 @@ impl NodeDuties {
                     .into(),
                     dst,
                     to_be_aggregated: false,
-                })
-                .into());
+                });
 
                 (stage, cmd)
             }
@@ -449,7 +445,7 @@ impl NodeDuties {
                         queued_ops: bootstrap.queued_ops.drain(..).collect(),
                     });
 
-                    let cmd = Ok(NodeMessagingDuty::Send(OutgoingMsg {
+                    let cmd = NodeMessagingDuty::Send(OutgoingMsg {
                         msg: NodeMessage::NodeCmd {
                             cmd: NodeCmd::System(NodeSystemCmd::AccumulateGenesis {
                                 signed_credit: signed_credit.clone(),
@@ -462,8 +458,7 @@ impl NodeDuties {
                             bootstrap.elder_state.section_public_key().into(),
                         ),
                         to_be_aggregated: false,
-                    })
-                    .into());
+                    });
 
                     (stage, cmd)
                 } else {
@@ -479,14 +474,14 @@ impl NodeDuties {
 
         self.stage = stage;
 
-        cmd
+        Ok(NetworkDuties::from(cmd))
     }
 
     async fn receive_genesis_accumulation(
         &mut self,
         signed_credit: SignedCredit,
         sig: SignatureShare,
-    ) -> Result<Vec<NetworkDuty>> {
+    ) -> Result<NetworkDuties> {
         if matches!(self.stage, Stage::Elder(_)) {
             return Ok(vec![]);
         }
@@ -548,7 +543,7 @@ impl NodeDuties {
         &mut self,
         wallet_info: WalletInfo,
         genesis: Option<TransferPropagated>,
-    ) -> Result<Vec<NetworkDuty>> {
+    ) -> Result<NetworkDuties> {
         let queued_duties = &mut VecDeque::new();
         let queued_duties = match self.stage {
             Stage::Elder(_) => return Ok(vec![]),
@@ -568,17 +563,17 @@ impl NodeDuties {
 
         trace!("Finishing transition to Elder..");
 
-        let mut ops: Vec<Vec<NetworkDuty>> = vec![];
+        let mut ops: NetworkDuties = vec![];
         let state = ElderState::new(self.network_api.clone()).await?;
         let mut duties = ElderDuties::new(wallet_info, &self.node_info, state.clone()).await?;
 
         // 1. Initiate duties.
-        ops.push(duties.initiate(genesis).await?);
+        ops.extend(duties.initiate(genesis).await?);
 
         // 2. Process all enqueued duties.
         for duty in queued_duties.drain(..) {
             debug!("queued duty: {:?}", duty);
-            ops.push(duties.process_elder_duty(duty).await?);
+            ops.extend(duties.process_elder_duty(duty).await?);
         }
 
         // 3. Set new stage
@@ -596,29 +591,23 @@ impl NodeDuties {
         let node_id = state.node_name();
 
         // 4. Add own node id to rewards.
-        ops.push(
-            RewardDuty::ProcessCmd {
-                cmd: RewardCmd::AddNewNode(node_id),
-                msg_id: MessageId::new(),
-                origin: SrcLocation::Node(node_id),
-            }
-            .into(),
-        );
+        ops.push(NetworkDuty::from(RewardDuty::ProcessCmd {
+            cmd: RewardCmd::AddNewNode(node_id),
+            msg_id: MessageId::new(),
+            origin: SrcLocation::Node(node_id),
+        }));
 
         // 5. Add own wallet to rewards.
-        ops.push(
-            RewardDuty::ProcessCmd {
-                cmd: RewardCmd::SetNodeWallet {
-                    node_id,
-                    wallet_id: self.node_info.reward_key,
-                },
-                msg_id: MessageId::new(),
-                origin: SrcLocation::Node(node_id),
-            }
-            .into(),
-        );
+        ops.push(NetworkDuty::from(RewardDuty::ProcessCmd {
+            cmd: RewardCmd::SetNodeWallet {
+                node_id,
+                wallet_id: self.node_info.reward_key,
+            },
+            msg_id: MessageId::new(),
+            origin: SrcLocation::Node(node_id),
+        }));
 
-        Ok(ops.into())
+        Ok(ops)
     }
 
     ///
@@ -626,7 +615,7 @@ impl NodeDuties {
         &mut self,
         prefix: sn_routing::Prefix,
         new_section_key: PublicKey,
-    ) -> Result<Vec<NetworkDuty>> {
+    ) -> Result<NetworkDuties> {
         match &mut self.stage {
             Stage::Infant => Ok(vec![]),
             Stage::AssumingElderDuties(_) => Ok(vec![]), // TODO: Queue up (or something?)!!
@@ -648,7 +637,7 @@ impl NodeDuties {
         &mut self,
         previous_key: PublicKey,
         new_key: PublicKey,
-    ) -> Result<Vec<NetworkDuty>> {
+    ) -> Result<NetworkDuties> {
         match &mut self.stage {
             Stage::AwaitingGenesisThreshold(_) => Ok(vec![]),
             Stage::ProposingGenesis(_) => Ok(vec![]),

--- a/src/node/node_duties/msg_analysis.rs
+++ b/src/node/node_duties/msg_analysis.rs
@@ -9,7 +9,7 @@
 use crate::{
     node::node_ops::{
         AdultDuty, ChunkReplicationCmd, ChunkReplicationDuty, ChunkReplicationQuery, ElderDuty,
-        MetadataDuty, NodeDuty, NodeMessagingDuty, NodeOperation, OutgoingMsg, RewardCmd,
+        MetadataDuty, NodeDuty, NodeMessagingDuty,  OutgoingMsg, RewardCmd,
         RewardDuty, RewardQuery, TransferCmd, TransferDuty, TransferQuery,
     },
     AdultState, Error, NodeState, Result,
@@ -38,7 +38,7 @@ impl ReceivedMsgAnalysis {
         Self { state }
     }
 
-    pub fn evaluate_node_msg(&self, msg: NodeMessage, src: SrcLocation) -> Result<NodeOperation> {
+    pub fn evaluate_node_msg(&self, msg: NodeMessage, src: SrcLocation) -> Result<Vec<NetworkDuty>> {
         debug!(".. node msg ..");
 
         use SrcLocation::*;
@@ -56,7 +56,7 @@ impl ReceivedMsgAnalysis {
         &self,
         msg: ClientMessage,
         dst: DstLocation,
-    ) -> Result<NodeOperation> {
+    ) -> Result<Vec<NetworkDuty>> {
         debug!(".. evaluating response to client ..");
 
         if !matches!(dst, DstLocation::EndUser(_)) {
@@ -93,7 +93,7 @@ impl ReceivedMsgAnalysis {
         &self,
         msg: ClientMessage,
         origin: EndUser,
-    ) -> Result<NodeOperation> {
+    ) -> Result<Vec<NetworkDuty>> {
         match msg {
             ClientMessage::Query {
                 query: Query::Data(query),
@@ -138,7 +138,7 @@ impl ReceivedMsgAnalysis {
     }
 
     /// Accumulated messages (i.e. src == section)
-    fn match_section_msg(&self, msg: NodeMessage, origin: SrcLocation) -> Result<NodeOperation> {
+    fn match_section_msg(&self, msg: NodeMessage, origin: SrcLocation) -> Result<Vec<NetworkDuty>> {
         debug!("Evaluating received msg for Section: {:?}", msg);
 
         let res = match &msg {
@@ -382,7 +382,7 @@ impl ReceivedMsgAnalysis {
         Ok(res)
     }
 
-    fn match_node_msg(&self, msg: NodeMessage, origin: SrcLocation) -> Result<NodeOperation> {
+    fn match_node_msg(&self, msg: NodeMessage, origin: SrcLocation) -> Result<Vec<NetworkDuty>> {
         debug!("Evaluating received msg for Node: {:?}", msg);
 
         let res = match &msg {

--- a/src/node/node_duties/network_events.rs
+++ b/src/node/node_duties/network_events.rs
@@ -8,7 +8,7 @@
 
 use super::msg_analysis::ReceivedMsgAnalysis;
 use crate::{
-    node::node_ops::{ElderDuty, NodeDuty, },
+    node::node_ops::{ElderDuty, NetworkDuties, NetworkDuty, NodeDuty},
     Error,
 };
 use crate::{Network, Result};
@@ -53,18 +53,17 @@ impl NetworkEvents {
         &mut self,
         event: RoutingEvent,
         network: &Network,
-    ) -> Result<Vec<NetworkDuty>> {
+    ) -> Result<NetworkDuties> {
         use ElderDuty::*;
         trace!("Processing Routing Event: {:?}", event);
         match event {
             RoutingEvent::MemberLeft { name, age } => {
                 trace!("A node has left the section. Node: {:?}", name);
                 //self.log_node_counts().await;
-                Ok(ProcessLostMember {
+                Ok(NetworkDuties::from(ProcessLostMember {
                     name: XorName(name.0),
                     age,
-                }
-                .into())
+                }))
             }
             RoutingEvent::MemberJoined {
                 name,
@@ -76,18 +75,18 @@ impl NetworkEvents {
                 //self.log_node_counts().await;
                 if let Some(prev_name) = previous_name {
                     trace!("The new member is a Relocated Node");
-                    let first = ProcessRelocatedMember {
+                    let first = NetworkDuty::from(ProcessRelocatedMember {
                         old_node_id: XorName(prev_name.0),
                         new_node_id: XorName(name.0),
                         age,
-                    };
+                    });
 
                     // Switch joins_allowed off a new adult joining.
-                    let second = SwitchNodeJoin(false).into();
+                    let second = NetworkDuty::from(SwitchNodeJoin(false));
                     Ok(vec![first, second])
                 } else {
                     trace!("New node has just joined the network and is a fresh node.",);
-                    Ok(ProcessNewMember(XorName(name.0)).into())
+                    Ok(NetworkDuties::from(ProcessNewMember(XorName(name.0))))
                 }
             }
             RoutingEvent::ClientMessageReceived { msg, user, .. } => {
@@ -125,22 +124,19 @@ impl NetworkEvents {
                 prefix,
                 self_status_change,
             } => {
-                let initial_op = match self_status_change {
-                    NodeElderChange::Promoted => NodeDuty::AssumeElderDuties.into(),
-                    NodeElderChange::Demoted => NodeDuty::AssumeAdultDuties.into(),
+                let mut duties: NetworkDuties = match self_status_change {
+                    NodeElderChange::Promoted => NetworkDuties::from(NodeDuty::AssumeElderDuties),
+                    NodeElderChange::Demoted => NetworkDuties::from(NodeDuty::AssumeAdultDuties),
                     NodeElderChange::None => vec![],
                 };
-                let ops = vec![
-                    initial_op,
-                    NodeDuty::InitiateElderChange {
-                        prefix,
-                        key: PublicKey::Bls(key),
-                        elders: elders.into_iter().map(|e| XorName(e.0)).collect(),
-                    }
-                    .into(),
-                ];
 
-                Ok(ops.into())
+                duties.push(NetworkDuty::from(NodeDuty::InitiateElderChange {
+                    prefix,
+                    key: PublicKey::Bls(key),
+                    elders: elders.into_iter().map(|e| XorName(e.0)).collect(),
+                }));
+
+                Ok(duties)
             }
             RoutingEvent::Relocated { .. } => {
                 // Check our current status
@@ -148,7 +144,7 @@ impl NetworkEvents {
                 if age > MIN_AGE {
                     info!("Node promoted to Adult");
                     info!("Our Age: {:?}", age);
-                    Ok(NodeDuty::AssumeAdultDuties.into())
+                    Ok(NetworkDuties::from(NodeDuty::AssumeAdultDuties))
                 } else {
                     info!("Our AGE: {:?}", age);
                     Ok(vec![])

--- a/src/node/node_duties/network_events.rs
+++ b/src/node/node_duties/network_events.rs
@@ -8,7 +8,7 @@
 
 use super::msg_analysis::ReceivedMsgAnalysis;
 use crate::{
-    node::node_ops::{ElderDuty, NodeDuty, NodeOperation},
+    node::node_ops::{ElderDuty, NodeDuty, },
     Error,
 };
 use crate::{Network, Result};
@@ -53,7 +53,7 @@ impl NetworkEvents {
         &mut self,
         event: RoutingEvent,
         network: &Network,
-    ) -> Result<NodeOperation> {
+    ) -> Result<Vec<NetworkDuty>> {
         use ElderDuty::*;
         trace!("Processing Routing Event: {:?}", event);
         match event {
@@ -76,16 +76,15 @@ impl NetworkEvents {
                 //self.log_node_counts().await;
                 if let Some(prev_name) = previous_name {
                     trace!("The new member is a Relocated Node");
-                    let first: NodeOperation = ProcessRelocatedMember {
+                    let first = ProcessRelocatedMember {
                         old_node_id: XorName(prev_name.0),
                         new_node_id: XorName(name.0),
                         age,
-                    }
-                    .into();
+                    };
 
                     // Switch joins_allowed off a new adult joining.
-                    let second: NodeOperation = SwitchNodeJoin(false).into();
-                    Ok(vec![first, second].into())
+                    let second = SwitchNodeJoin(false).into();
+                    Ok(vec![first, second])
                 } else {
                     trace!("New node has just joined the network and is a fresh node.",);
                     Ok(ProcessNewMember(XorName(name.0)).into())
@@ -117,7 +116,7 @@ impl NetworkEvents {
                         )),
                     },
                     MessageType::NodeMessage(msg) => self.analysis.evaluate_node_msg(msg, src),
-                    _ => return Ok(NodeOperation::NoOp),
+                    _ => return Ok(vec![]),
                 }
             }
             RoutingEvent::EldersChanged {
@@ -129,7 +128,7 @@ impl NetworkEvents {
                 let initial_op = match self_status_change {
                     NodeElderChange::Promoted => NodeDuty::AssumeElderDuties.into(),
                     NodeElderChange::Demoted => NodeDuty::AssumeAdultDuties.into(),
-                    NodeElderChange::None => NodeOperation::NoOp,
+                    NodeElderChange::None => vec![],
                 };
                 let ops = vec![
                     initial_op,
@@ -152,11 +151,11 @@ impl NetworkEvents {
                     Ok(NodeDuty::AssumeAdultDuties.into())
                 } else {
                     info!("Our AGE: {:?}", age);
-                    Ok(NodeOperation::NoOp)
+                    Ok(vec![])
                 }
             }
             // Ignore all other events
-            _ => Ok(NodeOperation::NoOp),
+            _ => Ok(vec![]),
         }
     }
 }

--- a/src/node/node_ops.rs
+++ b/src/node/node_ops.rs
@@ -26,13 +26,13 @@ use std::fmt::Debug;
 use xor_name::XorName;
 
 pub trait IntoNodeOp {
-    fn convert(self) -> Result<NodeOperation>;
+    fn convert(self) -> Result<Vec<NetworkDuty>>;
 }
 
 impl IntoNodeOp for Result<NodeMessagingDuty> {
-    fn convert(self) -> Result<NodeOperation> {
+    fn convert(self) -> Result<Vec<NetworkDuty>> {
         match self? {
-            NodeMessagingDuty::NoOp => Ok(NodeOperation::NoOp),
+            NodeMessagingDuty::NoOp => Ok(vec![]),
             op => Ok(op.into()),
         }
     }
@@ -51,55 +51,6 @@ impl IntoNodeOp for Result<NodeMessagingDuty> {
 /// module, by which it leaves the process boundary of this node
 /// and is sent on the wire to some other destination(s) on the network.
 
-/// The main operation type
-/// which encompasses all duties
-/// carried out by the node in the network.
-#[derive(Debug)]
-pub enum NodeOperation {
-    /// A single operation.
-    Single(NetworkDuty),
-    /// Multiple operations, that will
-    /// be carried out sequentially.
-    Multiple(Vec<NetworkDuty>),
-    // No op.
-    NoOp,
-}
-
-impl NodeOperation {
-    fn from_many(ops: Vec<NodeOperation>) -> NodeOperation {
-        use NodeOperation::*;
-        if ops.is_empty() {
-            return NoOp;
-        }
-        if ops.len() == 1 {
-            let mut ops = ops;
-            return ops.remove(0);
-        }
-        let multiple = ops
-            .into_iter()
-            .map(|c| match c {
-                Single(duty) => vec![duty],
-                Multiple(duties) => duties,
-                NoOp => vec![],
-            })
-            .flatten()
-            .collect();
-        Multiple(multiple)
-    }
-}
-
-impl Into<NodeOperation> for Vec<NodeOperation> {
-    fn into(self) -> NodeOperation {
-        NodeOperation::from_many(self.into_iter().collect())
-    }
-}
-
-impl Into<NodeOperation> for Vec<Result<NodeOperation>> {
-    /// NB: This drops errors!
-    fn into(self) -> NodeOperation {
-        NodeOperation::from_many(self.into_iter().flatten().collect())
-    }
-}
 
 /// All duties carried out by
 /// a node in the network.
@@ -167,10 +118,9 @@ pub enum NodeDuty {
     StorageFull,
 }
 
-impl Into<NodeOperation> for NodeDuty {
-    fn into(self) -> NodeOperation {
+impl Into<Vec<NetworkDuty>> for NodeDuty {
+    fn into(self) -> Vec<NetworkDuty> {
         use NetworkDuty::*;
-        use NodeOperation::*;
         Single(RunAsNode(self))
     }
 }
@@ -243,19 +193,6 @@ pub enum NodeMessagingDuty {
     NoOp,
 }
 
-impl From<NodeMessagingDuty> for NodeOperation {
-    fn from(duty: NodeMessagingDuty) -> Self {
-        use NetworkDuty::*;
-        use NodeDuty::*;
-        use NodeOperation::*;
-        if matches!(duty, NodeMessagingDuty::NoOp) {
-            NodeOperation::NoOp
-        } else {
-            Single(RunAsNode(ProcessMessaging(duty)))
-        }
-    }
-}
-
 impl Debug for NodeMessagingDuty {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -304,12 +241,10 @@ pub enum ElderDuty {
     SwitchNodeJoin(bool),
 }
 
-impl Into<NodeOperation> for ElderDuty {
-    fn into(self) -> NodeOperation {
-        use NetworkDuty::*;
-        use NodeOperation::*;
+impl Into<Vec<NetworkDuty>> for ElderDuty {
+    fn into(self) -> Vec<NetworkDuty> {
         if matches!(self, ElderDuty::NoOp) {
-            NodeOperation::NoOp
+            vec![]
         } else {
             Single(RunAsElder(self))
         }
@@ -328,12 +263,11 @@ pub enum AdultDuty {
     NoOp,
 }
 
-impl Into<NodeOperation> for AdultDuty {
-    fn into(self) -> NodeOperation {
+impl Into<Vec<NetworkDuty>> for AdultDuty {
+    fn into(self) -> Vec<NetworkDuty> {
         use NetworkDuty::*;
-        use NodeOperation::*;
         if matches!(self, AdultDuty::NoOp) {
-            NodeOperation::NoOp
+            vec![]
         } else {
             Single(RunAsAdult(self))
         }
@@ -350,13 +284,12 @@ pub enum KeySectionDuty {
     NoOp,
 }
 
-impl Into<NodeOperation> for KeySectionDuty {
-    fn into(self) -> NodeOperation {
+impl Into<Vec<NetworkDuty>> for KeySectionDuty {
+    fn into(self) -> Vec<NetworkDuty> {
         use ElderDuty::*;
         use NetworkDuty::*;
-        use NodeOperation::*;
         if matches!(self, KeySectionDuty::NoOp) {
-            NodeOperation::NoOp
+            vec![]
         } else {
             Single(RunAsElder(RunAsKeySection(self)))
         }
@@ -407,14 +340,13 @@ pub enum MetadataDuty {
     NoOp,
 }
 
-impl Into<NodeOperation> for MetadataDuty {
-    fn into(self) -> NodeOperation {
+impl Into<Vec<NetworkDuty>> for MetadataDuty {
+    fn into(self) -> Vec<NetworkDuty> {
         use DataSectionDuty::*;
         use ElderDuty::*;
         use NetworkDuty::*;
-        use NodeOperation::*;
         if matches!(self, MetadataDuty::NoOp) {
-            NodeOperation::NoOp
+            vec![]
         } else {
             Single(RunAsElder(RunAsDataSection(RunAsMetadata(self))))
         }
@@ -580,14 +512,13 @@ pub enum RewardQuery {
     GetSectionWalletHistory,
 }
 
-impl Into<NodeOperation> for RewardDuty {
-    fn into(self) -> NodeOperation {
+impl Into<Vec<NetworkDuty>> for RewardDuty {
+    fn into(self) -> Vec<NetworkDuty> {
         use DataSectionDuty::*;
         use ElderDuty::*;
         use NetworkDuty::*;
-        use NodeOperation::*;
         if matches!(self, RewardDuty::NoOp) {
-            NodeOperation::NoOp
+            vec![]
         } else {
             Single(RunAsElder(RunAsDataSection(RunAsRewards(self))))
         }
@@ -620,14 +551,13 @@ pub enum TransferDuty {
     NoOp,
 }
 
-impl Into<NodeOperation> for TransferDuty {
-    fn into(self) -> NodeOperation {
+impl Into<Vec<NetworkDuty>> for TransferDuty {
+    fn into(self) -> Vec<NetworkDuty> {
         use ElderDuty::*;
         use KeySectionDuty::*;
         use NetworkDuty::*;
-        use NodeOperation::*;
         if matches!(self, TransferDuty::NoOp) {
-            NodeOperation::NoOp
+            vec![]
         } else {
             Single(RunAsElder(RunAsKeySection(RunAsTransfers(self))))
         }

--- a/src/node/node_ops.rs
+++ b/src/node/node_ops.rs
@@ -9,7 +9,7 @@
 #[cfg(feature = "simulated-payouts")]
 use sn_data_types::Transfer;
 
-use crate::Result;
+use crate::{Network, Result};
 use sn_data_types::{
     Blob, BlobAddress, Credit, CreditAgreementProof, PublicKey, ReplicaEvent, SignatureShare,
     SignedCredit, SignedTransfer, SignedTransferShare, TransferAgreementProof, TransferValidated,
@@ -25,19 +25,6 @@ use std::collections::BTreeSet;
 use std::fmt::Debug;
 use xor_name::XorName;
 
-pub trait IntoNodeOp {
-    fn convert(self) -> Result<Vec<NetworkDuty>>;
-}
-
-impl IntoNodeOp for Result<NodeMessagingDuty> {
-    fn convert(self) -> Result<Vec<NetworkDuty>> {
-        match self? {
-            NodeMessagingDuty::NoOp => Ok(vec![]),
-            op => Ok(op.into()),
-        }
-    }
-}
-
 /// Internal messages are what is passed along
 /// within a node, between the entry point and
 /// exit point of remote messages.
@@ -51,6 +38,8 @@ impl IntoNodeOp for Result<NodeMessagingDuty> {
 /// module, by which it leaves the process boundary of this node
 /// and is sent on the wire to some other destination(s) on the network.
 
+/// Vec of NetworkDuty
+pub type NetworkDuties = Vec<NetworkDuty>;
 
 /// All duties carried out by
 /// a node in the network.
@@ -118,10 +107,21 @@ pub enum NodeDuty {
     StorageFull,
 }
 
-impl Into<Vec<NetworkDuty>> for NodeDuty {
-    fn into(self) -> Vec<NetworkDuty> {
+impl From<NodeDuty> for NetworkDuties {
+    fn from(duty: NodeDuty) -> Self {
         use NetworkDuty::*;
-        Single(RunAsNode(self))
+        if matches!(duty, NodeDuty::NoOp) {
+            vec![]
+        } else {
+            vec![RunAsNode(duty)]
+        }
+    }
+}
+
+impl From<NodeDuty> for NetworkDuty {
+    fn from(duty: NodeDuty) -> Self {
+        use NetworkDuty::*;
+        RunAsNode(duty)
     }
 }
 
@@ -193,6 +193,26 @@ pub enum NodeMessagingDuty {
     NoOp,
 }
 
+impl From<NodeMessagingDuty> for NetworkDuties {
+    fn from(duty: NodeMessagingDuty) -> Self {
+        use NetworkDuty::*;
+        use NodeDuty::*;
+        if matches!(duty, NodeMessagingDuty::NoOp) {
+            vec![]
+        } else {
+            vec![RunAsNode(ProcessMessaging(duty))]
+        }
+    }
+}
+
+impl From<NodeMessagingDuty> for NetworkDuty {
+    fn from(duty: NodeMessagingDuty) -> Self {
+        use NetworkDuty::*;
+        use NodeDuty::*;
+        RunAsNode(ProcessMessaging(duty))
+    }
+}
+
 impl Debug for NodeMessagingDuty {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -241,13 +261,21 @@ pub enum ElderDuty {
     SwitchNodeJoin(bool),
 }
 
-impl Into<Vec<NetworkDuty>> for ElderDuty {
-    fn into(self) -> Vec<NetworkDuty> {
-        if matches!(self, ElderDuty::NoOp) {
+impl From<ElderDuty> for NetworkDuties {
+    fn from(duty: ElderDuty) -> Self {
+        use NetworkDuty::*;
+        if matches!(duty, ElderDuty::NoOp) {
             vec![]
         } else {
-            Single(RunAsElder(self))
+            vec![RunAsElder(duty)]
         }
+    }
+}
+
+impl From<ElderDuty> for NetworkDuty {
+    fn from(duty: ElderDuty) -> Self {
+        use NetworkDuty::*;
+        RunAsElder(duty)
     }
 }
 
@@ -263,14 +291,21 @@ pub enum AdultDuty {
     NoOp,
 }
 
-impl Into<Vec<NetworkDuty>> for AdultDuty {
-    fn into(self) -> Vec<NetworkDuty> {
+impl From<AdultDuty> for NetworkDuties {
+    fn from(duty: AdultDuty) -> Self {
         use NetworkDuty::*;
-        if matches!(self, AdultDuty::NoOp) {
+        if matches!(duty, AdultDuty::NoOp) {
             vec![]
         } else {
-            Single(RunAsAdult(self))
+            vec![RunAsAdult(duty)]
         }
+    }
+}
+
+impl From<AdultDuty> for NetworkDuty {
+    fn from(duty: AdultDuty) -> Self {
+        use NetworkDuty::*;
+        RunAsAdult(duty)
     }
 }
 
@@ -284,14 +319,14 @@ pub enum KeySectionDuty {
     NoOp,
 }
 
-impl Into<Vec<NetworkDuty>> for KeySectionDuty {
-    fn into(self) -> Vec<NetworkDuty> {
+impl From<KeySectionDuty> for NetworkDuties {
+    fn from(duty: KeySectionDuty) -> Self {
         use ElderDuty::*;
         use NetworkDuty::*;
-        if matches!(self, KeySectionDuty::NoOp) {
+        if matches!(duty, KeySectionDuty::NoOp) {
             vec![]
         } else {
-            Single(RunAsElder(RunAsKeySection(self)))
+            vec![RunAsElder(RunAsKeySection(duty))]
         }
     }
 }
@@ -340,15 +375,15 @@ pub enum MetadataDuty {
     NoOp,
 }
 
-impl Into<Vec<NetworkDuty>> for MetadataDuty {
-    fn into(self) -> Vec<NetworkDuty> {
+impl From<MetadataDuty> for NetworkDuties {
+    fn from(duty: MetadataDuty) -> Self {
         use DataSectionDuty::*;
         use ElderDuty::*;
         use NetworkDuty::*;
-        if matches!(self, MetadataDuty::NoOp) {
+        if matches!(duty, MetadataDuty::NoOp) {
             vec![]
         } else {
-            Single(RunAsElder(RunAsDataSection(RunAsMetadata(self))))
+            vec![RunAsElder(RunAsDataSection(RunAsMetadata(duty)))]
         }
     }
 }
@@ -512,16 +547,25 @@ pub enum RewardQuery {
     GetSectionWalletHistory,
 }
 
-impl Into<Vec<NetworkDuty>> for RewardDuty {
-    fn into(self) -> Vec<NetworkDuty> {
+impl From<RewardDuty> for NetworkDuties {
+    fn from(duty: RewardDuty) -> Self {
         use DataSectionDuty::*;
         use ElderDuty::*;
         use NetworkDuty::*;
-        if matches!(self, RewardDuty::NoOp) {
+        if matches!(duty, RewardDuty::NoOp) {
             vec![]
         } else {
-            Single(RunAsElder(RunAsDataSection(RunAsRewards(self))))
+            vec![RunAsElder(RunAsDataSection(RunAsRewards(duty)))]
         }
+    }
+}
+
+impl From<RewardDuty> for NetworkDuty {
+    fn from(duty: RewardDuty) -> Self {
+        use DataSectionDuty::*;
+        use ElderDuty::*;
+        use NetworkDuty::*;
+        RunAsElder(RunAsDataSection(RunAsRewards(duty)))
     }
 }
 
@@ -551,15 +595,15 @@ pub enum TransferDuty {
     NoOp,
 }
 
-impl Into<Vec<NetworkDuty>> for TransferDuty {
-    fn into(self) -> Vec<NetworkDuty> {
+impl From<TransferDuty> for NetworkDuties {
+    fn from(duty: TransferDuty) -> Self {
         use ElderDuty::*;
         use KeySectionDuty::*;
         use NetworkDuty::*;
-        if matches!(self, TransferDuty::NoOp) {
+        if matches!(duty, TransferDuty::NoOp) {
             vec![]
         } else {
-            Single(RunAsElder(RunAsKeySection(RunAsTransfers(self))))
+            vec![RunAsElder(RunAsKeySection(RunAsTransfers(duty)))]
         }
     }
 }

--- a/src/node/node_ops.rs
+++ b/src/node/node_ops.rs
@@ -9,7 +9,6 @@
 #[cfg(feature = "simulated-payouts")]
 use sn_data_types::Transfer;
 
-use crate::{Network, Result};
 use sn_data_types::{
     Blob, BlobAddress, Credit, CreditAgreementProof, PublicKey, ReplicaEvent, SignatureShare,
     SignedCredit, SignedTransfer, SignedTransferShare, TransferAgreementProof, TransferValidated,


### PR DESCRIPTION
- Removes `NodeOperation` 
- Adds`NetworkDuties` which is a `Vec<NetworkDuty>`
- Returns `NetworkDuties` and /or extends it. no vec of vecs now.
- Uses `NetworkDuty/ies::from` instead of `into` for clarity